### PR TITLE
Allow neuron executable to run on arbitrary notes dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # neuron
 
-**NOTE**: Not yet ready for public use.
-
 neuron is a system for managing your plain-text [Zettelkasten](https://writingcooperative.com/zettelkasten-how-one-german-scholar-was-so-freakishly-productive-997e4e0ca125) notes. 
 
 **Features**
@@ -9,14 +7,7 @@ neuron is a system for managing your plain-text [Zettelkasten](https://writingco
 - Static site generation of notes, for easy browsing
   - Graph-based automatic category tree view
 - CLI for creating new zettel
-- Exposed Haskell library to build your own system
-
-See [srid.ca](https://github.com/srid/srid.ca) for a real-world example.
-
-**Roadmap**
-
-- Nix-based nvim for searching and editing Zettels
-- Weblog adapter on top
+- Use the `neuron` executable to work with a directory of your notes, or extend in Haskell using the neuron library.
 
 ## Prerequisites
 
@@ -35,12 +26,16 @@ nix-env -iA cachix -f https://cachix.org/api/v1/install
 cachix use srid
 ```
 
-## Guide
+## Running
 
-`TODO` Write a nice guide (using neuron itself) to using neuron, including topics like:
+- Use your own notes, or get the "content" directory from [srid.ca](https://github.com/srid/srid.ca) for demonstration.
+- Run `nix-build` to build the "neuron" executable
+- Run `./result/bin/neuron /path/to/content/dir rib serve`
 
-- [ ] ZettelID (timestamp based, or custom text)
-- [ ] Zettel graph and tree filtering
-- [ ] Zettel link schemes: z://, zcf://
-  - [ ] Zettel query: zquery://
-- [ ] zettel CLI to make new zettels
+This should generate HTML, and spin up a web server at http://localhost:8080 where you can view your Zettelkasten.
+
+### Creating new zettels
+
+```
+vim $(./result/bin/neuron /path/to/content/dir new "Some title")
+```

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "b668e2626fe5ab824d43215f1e936ccc1ec1a921";
+  ribRevision = "43950d766ea3ee8faf6e4248ab2a56e98924b7d1";
 
   inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
   neuronRoot = gitignoreSource ./.;

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -47,6 +47,7 @@ library
     modern-uri,
     foldl,
     filepattern,
+    filepath,
     algebraic-graphs >= 0.5
 
 executable neuron

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -21,9 +21,8 @@ import Relude
 import qualified Rib
 import Rib.Extra.CSS (googleFonts, stylesheet)
 
--- TODO: content/dest should be taken as command line arguments.
 main :: IO ()
-main = Z.run [reldir|content|] [reldir|dest|] generateSite
+main = Z.run generateSite
 
 generateSite :: Action ()
 generateSite = do


### PR DESCRIPTION
Ex:

```
nix-shell --run 'ghcid -c "cabal new-repl exe:neuron" -T ":main /path/to/notesdir rib serve"'
```