### PR TITLE
Add configuration support

### DIFF
--- a/guide/2011405.md
+++ b/guide/2011405.md
@@ -10,5 +10,6 @@ neuron ./notes rib serve
 
 ## Features 
 
+* [2011701](z://configuration)
 * [2011503](z://graph-view)
 

--- a/guide/2011701.md
+++ b/guide/2011701.md
@@ -1,0 +1,15 @@
+---
+title: Configuration
+---
+
+You may configure the parameters of your web interface by adding an optional configuration file named `neuron.dhall` under the notes directory. It should contain:
+
+```json
+{ siteTitle =
+    "My Zettelkasten for college"
+, author =
+    Some "John"
+, siteBaseUrl =
+    Some "https://somecollege.edu/~john/neuron"
+}
+```

--- a/guide/2011701.md
+++ b/guide/2011701.md
@@ -4,6 +4,17 @@ title: Configuration
 
 You may configure the parameters of your web interface by adding an optional configuration file named `neuron.dhall` under the notes directory. It should contain:
 
+## Supported fields
+
+* **`siteTitle`**: The title of your Neuron site.
+
+* **`author`**: Author name.
+
+* **`siteBaseUrl`**: The base URL of your published Neuron site.
+
+
+## Example 
+
 ```json
 { siteTitle =
     "My Zettelkasten for college"
@@ -13,3 +24,4 @@ You may configure the parameters of your web interface by adding an optional con
     Some "https://somecollege.edu/~john/neuron"
 }
 ```
+

--- a/guide/neuron.dhall
+++ b/guide/neuron.dhall
@@ -1,0 +1,7 @@
+{ siteTitle =
+    "Neuron"
+, author =
+    None Text
+, siteBaseUrl =
+    Some "https://neuron.srid.ca"
+}

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -24,6 +24,7 @@ library
     Neuron.Zettelkasten.Link.Action
     Neuron.Zettelkasten.Meta
     Neuron.Zettelkasten.Type
+    Neuron.Zettelkasten.Config
   other-modules:
     Neuron.Zettelkasten.ID
   build-depends:
@@ -48,7 +49,8 @@ library
     foldl,
     filepattern,
     filepath,
-    algebraic-graphs >= 0.5
+    algebraic-graphs >= 0.5,
+    dhall
 
 executable neuron
   hs-source-dirs: src-bin

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -14,6 +14,7 @@ import Development.Shake
 import Lucid
 -- TODO: Don't expose every module
 import qualified Neuron.Zettelkasten as Z
+import qualified Neuron.Zettelkasten.Config as Z
 import qualified Neuron.Zettelkasten.Route as Z
 import qualified Neuron.Zettelkasten.View as Z
 import Path
@@ -27,21 +28,15 @@ main = Z.run generateSite
 generateSite :: Action ()
 generateSite = do
   Rib.buildStaticFiles [[relfile|static/**|]]
-  let site :: Z.Site =
-        Z.Site
-          { Z.siteTitle = "Neuron",
-            Z.siteAuthor = Nothing,
-            Z.siteDescription = Nothing,
-            Z.siteBaseUrl = Nothing
-          }
-      writeHtmlRoute :: Z.Route s g () -> (s, g) -> Action ()
-      writeHtmlRoute r = Rib.writeRoute r . Lucid.renderText . renderPage site r
+  config <- Z.getConfig
+  let writeHtmlRoute :: Z.Route s g () -> (s, g) -> Action ()
+      writeHtmlRoute r = Rib.writeRoute r . Lucid.renderText . renderPage config r
   void $ Z.generateSite writeHtmlRoute [[relfile|*.md|]]
 
-renderPage :: Z.Site -> Z.Route s g () -> (s, g) -> Html ()
-renderPage site r val = html_ [lang_ "en"] $ do
+renderPage :: Z.Config -> Z.Route s g () -> (s, g) -> Html ()
+renderPage config r val = html_ [lang_ "en"] $ do
   head_ $ do
-    Z.renderRouteHead site r (fst val)
+    Z.renderRouteHead config r (fst val)
     stylesheet "https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"
     stylesheet "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
     style_ [type_ "text/css"] $ C.render style

--- a/src-dhall/Neuron.dhall
+++ b/src-dhall/Neuron.dhall
@@ -1,0 +1,1 @@
+{ siteTitle : Text, author : Optional Text, siteBaseUrl : Optional Text }

--- a/src/Neuron/Zettelkasten/Config.hs
+++ b/src/Neuron/Zettelkasten/Config.hs
@@ -33,7 +33,7 @@ getConfig = do
     configPath = [relfile|neuron.dhall|]
     defaultConfig =
       Config
-        { siteTitle = "My Zettelkasten",
+        { siteTitle = "Neuron Zettelkasten",
           author = mempty,
           siteBaseUrl = mempty
         }

--- a/src/Neuron/Zettelkasten/Config.hs
+++ b/src/Neuron/Zettelkasten/Config.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Zettelkasten config
+module Neuron.Zettelkasten.Config where
+
+import Development.Shake (Action)
+import Dhall.TH
+import Path
+import Path.IO (doesFileExist)
+import Relude
+import qualified Rib
+import qualified Rib.Parser.Dhall as Dhall
+
+makeHaskellTypes
+  [ SingleConstructor "Config" "Config" "./src-dhall/Neuron.dhall"
+  ]
+
+getConfig :: Action Config
+getConfig = do
+  inputDir <- Rib.ribInputDir
+  doesFileExist (inputDir </> configPath) >>= \case
+    True -> Dhall.parse [] configPath
+    False -> pure defaultConfig
+  where
+    configPath = [relfile|neuron.dhall|]
+    defaultConfig =
+      Config
+        { siteTitle = "My Zettelkasten",
+          author = mempty,
+          siteBaseUrl = mempty
+        }

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -21,6 +21,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Tree (Tree (..))
 import Lucid
+import Neuron.Zettelkasten.Config
 import Neuron.Zettelkasten.Graph
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link (linkActionExt)
@@ -35,12 +36,12 @@ import qualified Rib.Parser.MMark as MMark
 import Text.MMark (useExtension)
 import Text.Pandoc.Highlighting (styleToCss, tango)
 
-renderRouteHead :: Monad m => Site -> Route store graph a -> store -> HtmlT m ()
-renderRouteHead site r val = do
+renderRouteHead :: Monad m => Config -> Route store graph a -> store -> HtmlT m ()
+renderRouteHead config r val = do
   meta_ [httpEquiv_ "Content-Type", content_ "text/html; charset=utf-8"]
   meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
-  title_ $ toHtml $ routeTitle site val r
-  toHtml $ routeOpenGraph site val r
+  title_ $ toHtml $ routeTitle config val r
+  toHtml $ routeOpenGraph config val r
   style_ [type_ "text/css"] $ styleToCss tango
 
 renderRouteBody :: Monad m => Route store graph a -> (store, graph) -> HtmlT m ()


### PR DESCRIPTION
An optional `neuron.dhall` if it exists in the notes directory will be used by Neuron. Otherwise default values will be used. See `./guide/neuron.dhall` for an example. 

Documented at https://neuron.srid.ca/2011701.html

Fixes #15 