### PR TITLE
feat(nav): Add z-index on the 'Navigate up' section

### DIFF
--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -58,9 +58,17 @@ renderZettelLink ltheme store zid = do
       -- A normal looking link.
       -- Zettel's title is the link text.
       if Just zid == ignoreZid
-        then div_ [class_ "zettel-link item active", title_ $ unZettelID zid] $ do
-          span_ [class_ "zettel-link-title"] $ do
-            b_ $ toHtml zettelTitle
-        else a_ [class_ "zettel-link item", href_ zurl, title_ $ unZettelID zid] $ do
-          span_ [class_ "zettel-link-title"] $ do
-            toHtml zettelTitle
+        then renderActiveLink (unZettelID zid) zettelTitle
+        else renderLink zurl (unZettelID zid) zettelTitle
+
+renderLink :: forall a m. (Monad m, ToHtml a) => Text -> Text -> a -> HtmlT m ()
+renderLink url title label =
+  a_ [class_ "zettel-link item", href_ url, title_ title] $ do
+    span_ [class_ "zettel-link-title"] $ do
+      toHtml label
+
+renderActiveLink :: forall a m. (Monad m, ToHtml a) => Text -> a -> HtmlT m ()
+renderActiveLink title label =
+  div_ [class_ "zettel-link item active", title_ title] $ do
+    span_ [class_ "zettel-link-title"] $ do
+      b_ $ toHtml label

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -26,7 +26,7 @@ import Neuron.Zettelkasten.Graph
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link (linkActionExt)
 import Neuron.Zettelkasten.Link.Action (LinkTheme (..))
-import Neuron.Zettelkasten.Link.View (renderZettelLink)
+import Neuron.Zettelkasten.Link.View (renderZettelLink, renderLink)
 import Neuron.Zettelkasten.Route
 import Neuron.Zettelkasten.Store
 import Neuron.Zettelkasten.Type
@@ -87,6 +87,9 @@ renderIndex (store, graph) = do
     h2_ "Tree"
     ul_ $ renderForest Nothing LinkTheme_Default store graph forest
 
+zIndexLabel :: Text
+zIndexLabel = "z-index"
+
 renderZettel :: Monad m => (ZettelStore, ZettelGraph) -> ZettelID -> HtmlT m ()
 renderZettel (store, graph) zid = do
   let Zettel {..} = lookupStore zid store
@@ -106,10 +109,11 @@ renderZettel (store, graph) zid = do
           div_ [class_ "ui header"] "Navigate up"
           let forestB = obviateRootUnlessForest zid $ dfsForestBackwards zid graph
           ul_ $ do
-            li_ $ do
-              a_ [class_ "zettel-link item", href_ "/z-index.html", title_ "z-index"] $ do
-                span_ [class_ "zettel-link-title"] "z-index"
             renderForest Nothing (LinkTheme_Simple $ Just zid) store graph forestB
+      div_ [class_ "ui two column grid"] $ do
+        div_ [class_ "column"] $ do
+          div_ [class_ "ui header"] "Others"
+          renderLink "/z-index.html" zIndexLabel zIndexLabel
 
 renderForest ::
   Monad m =>

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -105,7 +105,11 @@ renderZettel (store, graph) zid = do
         div_ [class_ "column"] $ do
           div_ [class_ "ui header"] "Navigate up"
           let forestB = obviateRootUnlessForest zid $ dfsForestBackwards zid graph
-          ul_ $ renderForest Nothing (LinkTheme_Simple $ Just zid) store graph forestB
+          ul_ $ do
+            li_ $ do
+              a_ [class_ "zettel-link item", href_ "/z-index.html", title_ "z-index"] $ do
+                span_ [class_ "zettel-link-title"] "z-index"
+            renderForest Nothing (LinkTheme_Simple $ Just zid) store graph forestB
 
 renderForest ::
   Monad m =>


### PR DESCRIPTION
This PR adds a link to the `z-index` in the "Navigate up" section as a quick way to go back to the graph view.

<img width="718" alt="Screenshot 2020-03-23 at 19 04 38" src="https://user-images.githubusercontent.com/8309423/77348406-b4141580-6d39-11ea-82a7-53acd665342c.png">

NOTE: I'm not familiar with Rib and the Nueron codebase. Please let me know what should be changed.
