### PR TITLE
Remove hardcoded index zettel

### DIFF
--- a/guide/2011406.md
+++ b/guide/2011406.md
@@ -15,7 +15,7 @@ This command will print the path to the file created. You may pass it directly t
 neuron ./notesdir new "My zettel title" | xargs -rt vim
 ```
 
-Newly created zettels will be part of [2012301](zcf://dangling) until you connect them to other zettels.
+Newly created zettels will be one of the [2012301](zcf://top-level) until you connect other zettels to them.
 
 ## Opening a Zettel by title
 

--- a/guide/2011502.md
+++ b/guide/2011502.md
@@ -42,7 +42,7 @@ neuron ./notes new "My first zettel" | xargs -rt vim
 
 This will open the `vim` text editor (you may of course use the text editor of your choice) with the newly created file and its title already filled in. Enter some text, and exit the editor. 
 
-Next, create an "overview" zettel called `index.md` which would be the welcoming page of our Zettelkasten web interface, and link it (see [2011504](zcf://linking)) to your first zettel (we will assume its filename is "2011501.md") in it:
+Next, create an "overview" zettel called `index.md` (it would be the welcoming page of our Zettelkasten web interface) and link it (see [2011504](zcf://linking)) to your first zettel (we will assume its filename is "2011501.md") in it:
 
 ```bash
 $ cat > ./notes/index.md

--- a/guide/2011503.md
+++ b/guide/2011503.md
@@ -6,7 +6,7 @@ A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_grap
 
 ## z-index 
 
-The z-index page (at `/z-index.html`; also linked in the footer) displays your Zettelkasten graph. Zettels that do not belong to the graph will appear under [2012301](z://dangling).
+The z-index page (at `/z-index.html`; also linked in the footer) displays your Zettelkasten graph, as well as a forest rendered with [2012301](z://top-level) as its roots.
 
 ## Connections
 

--- a/guide/2012301.md
+++ b/guide/2012301.md
@@ -1,5 +1,9 @@
 ---
-title: Dangling zettels
+title: Top-level zettels
 ---
 
-Zettels that are not linked to any other zettel is said to be "dangling", and they will be listed in the "Dangling zettels" section of your z-index (see [2011503](zcf://graph-view)). Establish connections with other zettels to make a zettel non-dangling.
+A top-level zettel from [2011503](zcf://graph-view) is any zettel that has no incoming links (see [2011504](zcf://linking)) from other zettels. They indicate one of the two things:
+
+- Index zettel (a portal into a portion of your Zettelkasten)
+- Dangling zettel (a zettel which is yet to be linked to your Zettelkasten).
+

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -104,4 +104,4 @@ data Connection
     Folgezettel
   | -- | Any other ordinary connection (eg: "See also")
     OrdinaryConnection
-  deriving (Eq, Show, Enum, Bounded)
+  deriving (Eq, Ord, Show, Enum, Bounded)

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -103,7 +103,7 @@ renderZettel Config {..} (store, graph) zid = do
           whenJust editUrl $ \urlPrefix ->
             a_ [href_ $ urlPrefix <> zettelIDSourceFileName zid, title_ "Edit this Zettel"] $ fa "fas fa-edit"
         div_ [class_ "center aligned column"] $ do
-          a_ [href_ (Rib.routeUrl Route_Index), title_ "All Zettels (z-index)"] $
+          a_ [href_ (Rib.routeUrlRel Route_Index), title_ "All Zettels (z-index)"] $
             fa "fas fa-tree"
 
 -- | Font awesome element


### PR DESCRIPTION
"index.md" is now no longer hardcoded as _the_ overview zettel. Therefore we now have multiple roots, thus the tree becomes a forest.

Consequently,
- "Dangling zettels" list is no more. Because the forest is now generated with all mother vertices as the initial vertices. This is one step towards the clustering feature in #18 
- "Clusters" sections is removed as well. It was a misnomer, which actually showed the strongly-connected components (makes no sense in a zettelkasten).
- Max depth of the left-side tree in the connections pane is now set to 2