### PR TITLE
Add back support for absolute paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "6ba865b4b9e4831cd484c868475004038d26fab8";
+  ribRevision = "5562878dbe1b0c0983c4b2e4e2310a51d743bd51";
 
   inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
   pkgs = import <nixpkgs> {};


### PR DESCRIPTION
Fixes #35 and contains https://github.com/srid/rib/pull/137

A side-effect of this change is that neuron will create the Shake database directory `.shake` under the user's notes directory, which is unlikely to be problematic.