### PR TITLE
Implement queries from the CLI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "2b64f56ef18e5a3efc8cfde50b7c28efb89cfbf1";
+  ribRevision = "f068383";
 
   inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
   pkgs = import <nixpkgs> {};
@@ -32,7 +32,6 @@ in import rib {
       neuron = neuronRoot;
       # Until https://github.com/obsidiansystems/which/pull/6 is merged
       which = builtins.fetchTarball "https://github.com/srid/which/archive/5061a97.tar.gz";
-      with-utf8 = builtins.fetchTarball "https://github.com/serokell/haskell-with-utf8/archive/v1.0.0.0.tar.gz";
     } // source-overrides;
     overrides = self: super: with pkgs.haskell.lib; {
       # We must add neuron-search as a runtime dependency to the 'neuron'

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -36,7 +36,7 @@ common library-common
     filepattern,
     filepath,
     algebraic-graphs >= 0.5,
-    dhall,
+    dhall >= 1.30,
     which,
     unix
 

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -46,6 +46,7 @@ library
     Neuron.Zettelkasten
     Neuron.Zettelkasten.Route
     Neuron.Zettelkasten.Store
+    Neuron.Zettelkasten.Query
     Neuron.Zettelkasten.Graph
     Neuron.Zettelkasten.View
     Neuron.Zettelkasten.Link

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -20,12 +20,14 @@ where
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Aeson.Text as Aeson
+import qualified Text.URI as URI
 import Development.Shake (Action)
 import qualified Neuron.Zettelkasten.Graph as Z
 import qualified Neuron.Zettelkasten.ID as Z
 import qualified Neuron.Zettelkasten.Route as Z
 import qualified Neuron.Zettelkasten.Store as Z
 import qualified Neuron.Zettelkasten.Query as Z
+import qualified Neuron.Zettelkasten.Link.Action as Z
 import Options.Applicative
 import Path
 import Path.IO
@@ -74,7 +76,8 @@ commandParser =
     newCommand =
       New <$> argument str (metavar "TITLE" <> help "Title of the new Zettel")
     queryCommand =
-      Query <$> many (Z.ByTag <$> option str (long "tag" <> short 't'))
+      fmap Query $ (many (Z.ByTag <$> option str (long "tag" <> short 't')))
+        <|> (Z.queryFromUri . fromMaybe URI.emptyURI . URI.mkURI <$> option str (long "uri" <> short 'u'))
     searchCommand =
       pure Search
 

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -19,11 +19,13 @@ module Neuron.Zettelkasten
 where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.Text.IO as Text
 import Development.Shake (Action)
 import qualified Neuron.Zettelkasten.Graph as Z
 import qualified Neuron.Zettelkasten.ID as Z
 import qualified Neuron.Zettelkasten.Route as Z
 import qualified Neuron.Zettelkasten.Store as Z
+import qualified Neuron.Zettelkasten.Link.Action as Z
 import Options.Applicative
 import Path
 import Path.IO
@@ -50,6 +52,8 @@ data Command
     New Text
   | -- | Search a zettel by title
     Search
+    -- | Query a zettelkasten and prints all macthing zettel IDs
+  | Query [Z.Query]
   | Rib Rib.App.Command
   deriving (Eq, Show)
 
@@ -64,10 +68,13 @@ commandParser =
         mconcat
           [ command "new" $ info newCommand $ progDesc "Create a new zettel",
             command "search" $ info searchCommand $ progDesc "Search zettels and print the matching filepath",
+            command "query" $ info queryCommand $ progDesc "Query a zettelkasten and print the IDs of all matching zettels",
             command "rib" $ fmap Rib $ info Rib.App.commandParser $ progDesc "Call rib"
           ]
     newCommand =
       New <$> argument str (metavar "TITLE" <> help "Title of the new Zettel")
+    queryCommand =
+      Query <$> many (Z.ByTag <$> option str (long "tag" <> short 't'))
     searchCommand =
       pure Search
 
@@ -90,10 +97,13 @@ runWith act App {..} = do
       putStrLn =<< newZettelFile inputDir tit
     Search ->
       execScript neuronSearchScript [notesDir]
-    Rib ribCmd -> do
-      -- CD to the parent of notes directory, because Rib API takes only
-      -- relative path
-      withCurrentDir (parent inputDir) $ do
+    Query queries -> do
+      paths <- snd <$> listDirRel inputDir
+      store <- Z.mkZettelStoreIO inputDir paths
+      mapM_ (Text.putStrLn . Z.unZettelID) (Z.runQuery store queries)
+    -- CD to the parent of notes directory, because Rib API takes only
+    -- relative path
+    Rib ribCmd ->  withCurrentDir (parent inputDir) $ do
         inputDirRel <- makeRelativeToCurrentDir inputDir
         outputDirRel <- makeRelativeToCurrentDir outputDir
         Rib.App.runWith inputDirRel outputDirRel act ribCmd

--- a/src/Neuron/Zettelkasten/Config.hs
+++ b/src/Neuron/Zettelkasten/Config.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -12,6 +13,7 @@
 module Neuron.Zettelkasten.Config where
 
 import Development.Shake (Action)
+import Dhall
 import Dhall.TH
 import Path
 import Path.IO (doesFileExist)
@@ -22,6 +24,10 @@ import qualified Rib.Parser.Dhall as Dhall
 makeHaskellTypes
   [ SingleConstructor "Config" "Config" "./src-dhall/Neuron.dhall"
   ]
+
+deriving instance Generic Config
+
+deriving instance FromDhall Config
 
 getConfig :: Action Config
 getConfig = do

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | Zettel ID
@@ -19,6 +20,7 @@ where
 
 import qualified Data.Text as T
 import Data.Time
+import Data.Aeson (ToJSON)
 import Lucid
 import Path
 import Relude
@@ -30,7 +32,7 @@ import Text.Printf
 --
 -- Based on https://old.reddit.com/r/Zettelkasten/comments/fa09zw/shorter_zettel_ids/
 newtype ZettelID = ZettelID {unZettelID :: Text}
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, ToJSON)
 
 instance ToHtml ZettelID where
   toHtmlRaw = toHtml

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -16,6 +16,7 @@ module Neuron.Zettelkasten.Link.View where
 
 import Lucid
 import Neuron.Zettelkasten.ID
+import Neuron.Zettelkasten.Query
 import Neuron.Zettelkasten.Link.Action
 import Neuron.Zettelkasten.Route (Route (..))
 import Neuron.Zettelkasten.Store
@@ -31,7 +32,7 @@ linkActionRender store MarkdownLink {..} = \case
     renderZettelLink LinkTheme_Default store zid
   LinkAction_QueryZettels _conn linkTheme q -> do
     toHtmlRaw @Text $ "<!--" <> show q <> "-->"
-    let zettels = reverse $ sortOn zettelIDDate $ runQuery store q
+    let zettels = reverse $ sortOn zettelIDDate $ matchID <$> runQuery store q
     ul_ $ do
       forM_ zettels $ \zid -> do
         li_ $ renderZettelLink linkTheme store zid

--- a/src/Neuron/Zettelkasten/Query.hs
+++ b/src/Neuron/Zettelkasten/Query.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Queries to the Zettel store
+module Neuron.Zettelkasten.Query where
+
+import qualified Data.Map.Strict as Map
+-- import qualified Data.Set as Set
+import Data.Aeson
+import Neuron.Zettelkasten.ID
+import qualified Neuron.Zettelkasten.Meta as Meta
+import Neuron.Zettelkasten.Store
+import Neuron.Zettelkasten.Type
+import Relude
+-- import Text.MMark (MMark, runScanner)
+-- import qualified Text.MMark.Extension as Ext
+-- import Text.MMark.Extension (Inline (..))
+-- import qualified Text.URI as URI
+
+data Query
+  = ByTag Text
+  -- | LinksTo ZettelID
+  -- | LinksFrom ZettelID
+  deriving (Eq, Show)
+
+data Match
+  = Match
+      { matchID        :: ZettelID
+      , matchTitle     :: Text
+      , matchTags      :: [Text]
+      -- , matchLinks     :: [ZettelID]
+      -- , matchBackLinks :: [ZettelID]
+      }
+
+instance ToJSON Match where
+  toJSON Match {..} = object
+    [ "id"    .= toJSON matchID
+    , "title" .= matchTitle
+    , "tags"  .= matchTags ]
+
+matchQuery :: Match -> Query -> Bool
+matchQuery Match {..} = \case
+  ByTag tag -> tag `elem` matchTags
+
+extractMatch :: Zettel -> Maybe Match
+extractMatch Zettel {..} = do
+  Meta.Meta {..} <- Meta.getMeta zettelContent
+  pure Match
+    { matchID    = zettelID
+    , matchTitle = zettelTitle
+    , matchTags  = fromMaybe [] tags
+    }
+
+runQuery :: ZettelStore -> [Query] -> [Match]
+runQuery store queries =
+    flip filter database $ \ match -> and $ matchQuery match <$> queries
+  where database = catMaybes $ extractMatch <$> Map.elems store

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -28,6 +28,7 @@ import Neuron.Zettelkasten.Link.Action (LinkTheme (..))
 import Neuron.Zettelkasten.Link.View (renderZettelLink)
 import Neuron.Zettelkasten.Route
 import Neuron.Zettelkasten.Store
+-- import Neuron.Zettelkasten.Query
 import Neuron.Zettelkasten.Type
 import Relude
 import qualified Rib


### PR DESCRIPTION
Implement `neuron ... query` command as described in #42 

About this suggestion:
> Maybe use this to find zettels by title or content with ripgrep, sort of like neuron ... search does but returning only the list of IDs instead of starting a fzf interface.

It would be easier to implement it as a `ByTitle` constructor in the `Query` type so it's not implemented in this PR.