### PR TITLE
Add math support documentation in guide

### DIFF
--- a/guide/2011404.md
+++ b/guide/2011404.md
@@ -6,4 +6,4 @@ Zettel files are written using the [Markdown](https://en.wikipedia.org/wiki/Mark
 
 * [2011504](z://linking)
 * [2011505](z://metadata)
-
+* [2013701](z://mathjax) 

--- a/guide/2013701.md
+++ b/guide/2013701.md
@@ -1,0 +1,29 @@
+---
+title: Math support
+---
+
+## LaTeX input
+
+You can type LaTeX code in zettels in two ways:
+
+* Inline: by surrounding your code with \`\$ ... \$\`
+* Block: surrounding your LaTeX expression with $$ will display it as a centered block
+* Multi-line block: \`\`\`mathjax ... \`\`\`
+
+## Examples
+
+* Inline `$ \LaTeX $` looks like this
+
+* Block:
+
+```mathjax
+(A = B) \cong (A \cong B)
+```
+
+## Warnings
+
+* The `mathjax` code block will treat each line as a separate LaTeX 
+  expression. Thus you can't write `\begin{...}` and `\end{...}` on multiple
+  lines.
+* $$ blocks don't seem to be supported by MMark, it is recommended to
+  use `mathjax` fenced code blocks as it correctly escapes other MMark features.


### PR DESCRIPTION
Add documentation about mathjax support from zettel markdown.
This is needed because MMark uses unconventional notation for LaTeX input.

Some features also have unexpected bugs as `$$ ... $$` blocks fail to escape some markdown features, in particular superscript and subscript (todo: figure out if these come from mmark-ext or from mathjax directly).