### PR TITLE
CLI revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist-*
 result
 .shake
 
-guide.output
+guide/.neuron

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Styling changes:
   - Tags are restyled and positioned below
   - Produce compact CSS in HTML head
+- CLI revamp
+  - Zettelkasten directory is now provided via the `-d` argument.
+    - Its default, `~/zettelkasten`, is used when not specified.
+    - This directory must exist, otherwise neuron will error out.
 
 ## 0.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - Zettelkasten directory is now provided via the `-d` argument.
     - Its default, `~/zettelkasten`, is used when not specified.
     - This directory must exist, otherwise neuron will error out.
+  - The output directory is now moved to `.neuron/output` under the Zettelkasten directory.
+  - Added `neuron open` to open the locally generated Zettelkasten site.
+  - `neuron ... rib serve` is now `neuron rib -wS`.
 
 ## 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ nix-shell --run ghcid
 You can test your changes by running it on the `./guide` (or any) zettelkasten as follows:
 
 ```bash
-bin/run ./guide rib serve
+bin/run ./guide rib -wS
 ```
 
 This command will also automatically recompile and restart when you change any of the Haskell source files.

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "19b1022442a0cde2a0b1d9373b0397030472721e";
+  ribRevision = "20208d9";
   projectRoot = ./.;
 in {
 # Rib library source to use

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "20208d9";
+  ribRevision = "77745c0";
   projectRoot = ./.;
 in {
 # Rib library source to use

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ let
   # To upgrade rib, go to https://github.com/srid/rib/commits/master, select the
   # revision you would like to upgrade to and set it here. Consult rib's
   # ChangeLog.md to check any notes on API migration.
-  ribRevision = "77745c0";
+  ribRevision = "c115fe3";
   projectRoot = ./.;
 in {
 # Rib library source to use

--- a/guide/2011405.md
+++ b/guide/2011405.md
@@ -2,11 +2,13 @@
 title: Web interface
 ---
 
-Neuron can generate HTML out of your zettelkasten so that they may be viewed on any other device's web browser. It generates the HTML files to a sibling directory of your notes directory. If your notes live at `./notes`, neuron will generate the HTML at `./notes.output/` as well as spin up a server that will serve that generate site at [localhost:8080](http://localhost:8080).
+Neuron can generate HTML out of your zettelkasten so that they may be viewed on any other device's web browser. It generates the HTML files under your Zettelkasten, in `.neuron/output/`. If your notes live at `./notes`, neuron will generate the HTML at `./notes/.neuron/output/` as well as spin up a server that will serve that generate site at [localhost:8080](http://localhost:8080).
 
 ```bash
-neuron ./notes rib serve
+neuron -d ~/path/to/your/zettelkasten rib -wS
 ```
+
+You can override the output directory path using `-o`.
 
 ## Features 
 

--- a/guide/2011406.md
+++ b/guide/2011406.md
@@ -7,14 +7,14 @@ tags:
 You may use any text editor with Markdown support to edit your zettel files. Neuron provides a command to create new zettel files with the suitable [2011403](zcf://zettel-id):
 
 ```bash
-neuron ./notesdir new "My zettel title"
+neuron -e ~/notes new "My zettel title"
 ```
 
-This command will print the path to the file created. You may pass it directly to your text editor like this:
+This command will print the path to the file created. Use `-e` to also open the text editor:
 
 
 ```bash
-neuron ./notesdir new "My zettel title" | xargs -rt vim
+neuron -e ~/notes new "My zettel title" -e
 ```
 
 Newly created zettels will be a cluster of its own (see [2012301](z://cluster)) until you connect other zettels to them.

--- a/guide/2011501.md
+++ b/guide/2011501.md
@@ -25,14 +25,10 @@ cachix use srid
 
 To install the last stable version of neuron, run:
 
-```bash
-nix-env -iE '_: let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; ref = "0.2.0.0"; }; in import src.outPath { gitRev = src.shortRev; }' --option tarball-ttl 0
-```
-
 If you prefer the latest development version of neuron, run instead:
 
 ```bash
-nix-env -iE '_: let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; }; in import src.outPath { gitRev = src.shortRev; }' --option tarball-ttl 0
+nix-env -iE '_: let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; ref = "master"; }; in import src.outPath { gitRev = src.shortRev; }' --option tarball-ttl 0
 ```
 
 For alternative mechanisms, see [2012401](z://decl-inst).

--- a/guide/2011502.md
+++ b/guide/2011502.md
@@ -20,7 +20,7 @@ cd neuron
 Now run the neuron [2011405](zcf://web-intr) on the `./guide` Zettelkasten:
 
 ```bash
-neuron ./guide rib serve
+neuron -d ./guide rib -wS
 ```
 
 It can be accessed at [localhost:8080](http://localhost:8080). It should match what you see at [neuron.srid.ca](https://neuron.srid.ca).
@@ -29,25 +29,24 @@ It can be accessed at [localhost:8080](http://localhost:8080). It should match w
 
 There are two ways to do this. You may copy the `./guide` directory and work from there; or create one from scratch. For this tutorial, we choose the latter.
 
-Neuron expects a Zettelkasten directory to be nothing more than a list of [2011404](zcf://z-md) notes. Create an empty directory:
+Neuron expects a Zettelkasten directory to be nothing more than a list of [2011404](zcf://z-md) notes. By default `~/zettelkasten` will be used as your neuron directory (which you can override using the `-d` option). Create this directory first:
 
 ```bash
-cd ~
-mkdir ./notes
+mkdir ~/zettelkasten
 ```
 
 Now create (see [2011406](zcf://editing)) your first zettel file:
 
 ```bash
-neuron ./notes new "My first zettel" | xargs -rt vim
+neuron new "My first zettel" -e
 ```
 
-This will open the `vim` text editor (you may of course use the text editor of your choice) with the newly created file and its title already filled in. Enter some text, and exit the editor. 
+This will open your text editor (per `$EDITOR` environment variable) with the newly created file and its title already filled in. Enter some text, and exit the editor. 
 
 Next, create an "overview" zettel called `index.md` (it would be the welcoming page of our Zettelkasten web interface) and link it (see [2011504](zcf://linking)) to your first zettel (we will assume its filename is "2011501.md") in it:
 
 ```bash
-$ cat > ./notes/index.md
+$ cat > ~/zettelkasten/index.md
 ---
 title: Overview
 ---
@@ -56,13 +55,16 @@ title: Overview
 $
 ```
 
-Your Zettelkasten directory should now contain two zettels---named `2011501.md` and `index.md`.  Now it is time to run the neuron [2011405](zcf://web-intr):
+Your Zettelkasten directory `~/zettelkasten` should now contain two zettels---named `2011501.md` and `index.md`.  Now it is time to run the neuron [2011405](zcf://web-intr):
 
 ```bash
-neuron ./notes rib serve 
+neuron rib -wS
 ```
 
-Access it at [localhost:8080](http://localhost:8080). You should expect to see the contents of your overview zettel, which should link to the first zettel created. Clicking the tree icon in the footer should take you to the [2011503](zcf://graph-view) of your Zettelkasten.
+* The `-w` option will watch your Zettelkasten directory and regenerate HTML files.
+* The `-S` option runs a HTTP server serving the generated HTML files. (You can ignore it, and use `neuron open` instead).
+
+Access it at [localhost:8080](http://localhost:8080). You should expect to see the contents of your overview zettel, which should link to the first zettel created. Clicking the tree icon in the footer should take you to the [2011503](zcf://graph-view) of your Zettelkasten. 
 
 ## Growing your Zettelkasten
 

--- a/guide/2012401.md
+++ b/guide/2012401.md
@@ -6,7 +6,7 @@ If you use [NixOS](https://nixos.org/), add the following to your `environment.s
 
 
 ```nix
-let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; ref = "0.2.0.0"; }; 
+let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; ref = "master"; }; 
  in import src.outPath { gitRev = src.shortRev; }
 ```
 
@@ -17,7 +17,8 @@ If you use [home-manager](https://github.com/rycee/home-manager), add the above 
 It is generally recommended to pin your imports in Nix. The above expression will fetch the then `master` branch, which is not what you want for reproducibility. Pick a revision from [the commit history](https://github.com/srid/neuron/commits/master), and then use it, for example:
 
 ```nix
-let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; rev = "11d47c32e9d7146fd4e7d5f9ef239d51ffcd7448"; }; 
+# This commit revision corresponds to the 0.2.0.0 release tag
+let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; rev = "274bcafe85fc2bae0a348ab91818d21c72d786db"; }; 
  in import src.outPath { gitRev = src.shortRev; }
 ```
 

--- a/guide/2013501.md
+++ b/guide/2013501.md
@@ -9,7 +9,7 @@ tags:
 Use the `search` command to search for a particular zettel:
 
 ```bash
-neuron ./notesdir search
+neuron -d ~/notes search
 ```
 
 This command will allow you to search your Zettels by title, and then print the matching zettel's filepath at the end. 
@@ -17,7 +17,7 @@ This command will allow you to search your Zettels by title, and then print the 
 You may pipe the command to your text editor in order to directly edit the matching Zettel:
 
 ```bash
-neuron ./notesdir search | xargs -rt vim
+neuron search | xargs -rt vim
 ```
 
 [![asciicast](https://asciinema.org/a/313358.png)](https://asciinema.org/a/313358)
@@ -28,17 +28,17 @@ Use the `query` command to query your Zettelkasten and return the matches in JSO
 
 ```bash
 # Returns all zettels
-neuron ./notesdir query
+neuron -d ~/notes query
 ```
 
 ```bash
 # Returns zettels with the specified tag
-neuron ./notesdir query -t science
+neuron query -t science
 ```
 
 You may also pass the same zquery URI you use in [2011506](zcf://linking-multiple):
 
 ```bash
 # Search using zquery
-neuron ./notesdir query --uri="zquery://search?tag=science"
+neuron query --uri="zquery://search?tag=science"
 ```

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -64,6 +64,7 @@ library
   exposed-modules:
     Neuron.Version
     Neuron.Zettelkasten
+    Neuron.Zettelkasten.CLI
     Neuron.Zettelkasten.Route
     Neuron.Zettelkasten.Store
     Neuron.Zettelkasten.Query

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.3.0.0
+version: 0.3.0.1
 license: BSD-3-Clause
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca
@@ -43,10 +43,8 @@ common library-common
     lucid -any,
     optparse-applicative,
     pandoc,
-    path,
-    path-io,
     relude,
-    rib ^>=0.8,
+    rib ^>=0.9,
     shake -any,
     time,
     text,

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -20,7 +20,6 @@ import qualified Neuron.Zettelkasten as Z
 import qualified Neuron.Zettelkasten.Config as Z
 import qualified Neuron.Zettelkasten.Route as Z
 import qualified Neuron.Zettelkasten.View as Z
-import Path
 import Relude
 import qualified Rib
 import Rib.Extra.CSS (googleFonts, stylesheet)
@@ -30,13 +29,13 @@ main = withUtf8 $ Z.run generateSite
 
 generateSite :: Action ()
 generateSite = do
-  Rib.buildStaticFiles [[relfile|static/**|]]
+  Rib.buildStaticFiles ["static/**"]
   config <- Z.getConfig
   when (olderThan $ Z.minVersion config) $ do
     error $ "Require neuron mininum version " <> Z.minVersion config <> ", but your neuron version is " <> neuronVersion
   let writeHtmlRoute :: Z.Route s g () -> (s, g) -> Action ()
       writeHtmlRoute r = Rib.writeRoute r . Lucid.renderText . renderPage config r
-  void $ Z.generateSite writeHtmlRoute [[relfile|*.md|]]
+  void $ Z.generateSite writeHtmlRoute ["*.md"]
 
 renderPage :: Z.Config -> Z.Route s g () -> (s, g) -> Html ()
 renderPage config r val = html_ [lang_ "en"] $ do

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -1,145 +1,38 @@
-{-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | Main module for using neuron as a library, instead of as a CLI tool.
 module Neuron.Zettelkasten
-  ( -- * CLI
-    App (..),
-    NewCommand (..),
-    commandParser,
+  ( generateSite,
     run,
-    runWith,
-
-    -- * Rib site generation
-    generateSite,
-
-    -- * Etc
-    newZettelFile,
   )
 where
 
 import qualified Data.Aeson.Text as Aeson
 import qualified Data.Map.Strict as Map
 import Development.Shake (Action)
-import Development.Shake (Verbosity (Silent, Verbose))
 import qualified Neuron.Version as Version
+import Neuron.Zettelkasten.CLI (App (..), Command (..), NewCommand (..), commandParser, runRib, runRibOnceQuietly)
 import qualified Neuron.Zettelkasten.Graph as Z
 import qualified Neuron.Zettelkasten.ID as Z
-import qualified Neuron.Zettelkasten.Link.Action as Z
 import qualified Neuron.Zettelkasten.Query as Z
 import qualified Neuron.Zettelkasten.Route as Z
 import qualified Neuron.Zettelkasten.Store as Z
 import Options.Applicative
 import Relude
 import qualified Rib
-import qualified Rib.App
-import qualified Rib.Cli
 import System.Directory
 import System.FilePath
 import qualified System.Posix.Env as Env
 import System.Posix.Process
 import System.Which
-import qualified Text.URI as URI
 
 neuronSearchScript :: FilePath
 neuronSearchScript = $(staticWhich "neuron-search")
-
-data App
-  = App
-      { notesDir :: FilePath,
-        cmd :: Command
-      }
-  deriving (Eq, Show)
-
-data NewCommand = NewCommand {title :: Text, edit :: Bool}
-  deriving (Eq, Show)
-
-data Command
-  = -- | Create a new zettel file
-    New NewCommand
-  | -- | Search a zettel by title
-    Search
-  | -- | Run a query against the Zettelkasten
-    Query [Z.Query]
-  | -- | Delegate to Rib's command parser
-    Rib RibConfig
-  deriving (Eq, Show)
-
-data RibConfig
-  = RibConfig
-      { ribOutputDir :: Maybe FilePath,
-        ribWatch :: Bool,
-        ribServe :: Maybe (Text, Int)
-      }
-  deriving (Eq, Show)
-
-mkRibCliConfig :: FilePath -> RibConfig -> IO Rib.Cli.CliConfig
-mkRibCliConfig inputDir cfg = do
-  unlessM (doesDirectoryExist inputDir) $ do
-    fail $ "Zettelkasten directory " <> inputDir <> " does not exist."
-  let neuronDir = inputDir </> ".neuron"
-      outputDir = fromMaybe (neuronDir </> "output") $ ribOutputDir cfg
-      rebuildAll = True
-      watch = ribWatch cfg
-      serve = ribServe cfg
-      verbosity = Verbose
-      shakeDbDir = neuronDir </> ".shake"
-      watchIgnore = [".neuron", ".git"]
-  pure Rib.Cli.CliConfig {..}
-
--- | optparse-applicative parser for neuron CLI
-commandParser :: FilePath -> Parser App
-commandParser defaultNotesDir = do
-  notesDir <-
-    option
-      Rib.Cli.directoryReader
-      ( long "zettelkasten-dir" <> short 'd' <> metavar "NOTESDIR" <> value defaultNotesDir
-          <> help ("Your zettelkasten directory containing the zettel files (" <> "default: " <> defaultNotesDir <> ")")
-      )
-  cmd <- cmdParser
-  pure $ App {..}
-  where
-    cmdParser =
-      hsubparser $
-        mconcat
-          [ command "new" $ info newCommand $ progDesc "Create a new zettel",
-            command "search" $ info searchCommand $ progDesc "Search zettels and print the matching filepath",
-            command "query" $ info queryCommand $ progDesc "Run a query against the zettelkasten",
-            command "rib" $ info ribCommand $ progDesc "Generate static site via rib"
-          ]
-    newCommand = do
-      edit <- switch (long "edit" <> short 'e' <> help "Open the newly-created file in $EDITOR")
-      title <- argument str (metavar "TITLE" <> help "Title of the new Zettel")
-      return (New NewCommand {..})
-    queryCommand =
-      fmap Query $
-        (many (Z.ByTag <$> option str (long "tag" <> short 't')))
-          <|> (Z.queryFromUri . mkURIMust <$> option str (long "uri" <> short 'u'))
-    searchCommand =
-      pure Search
-    ribCommand = fmap Rib $ do
-      ribOutputDir <-
-        optional $
-          option
-            Rib.Cli.directoryReader
-            ( long "output-dir" <> short 'o' <> metavar "OUTPUTDIR"
-                <> help ("The directory where HTML will be generated (" <> "default: NOTESDIR/.neuron/output)")
-            )
-      ribWatch <- Rib.Cli.watchOption
-      ribServe <- Rib.Cli.serveOption
-      pure RibConfig {..}
-    mkURIMust =
-      either (error . toText . displayException) id . URI.mkURI
 
 run :: Action () -> IO ()
 run act = do
@@ -163,20 +56,13 @@ runWith act App {..} = do
     Search ->
       execScript neuronSearchScript [notesDir]
     Query queries -> do
-      cfg <- oneOffCfg
-      flip Rib.App.runWith cfg $ do
+      runRibOnceQuietly notesDir $ do
         store <- Z.mkZettelStore =<< Rib.forEvery ["*.md"] pure
         let matches = Z.runQuery store queries
         putLTextLn $ Aeson.encodeToLazyText $ matches
     Rib ribCfg ->
-      Rib.App.runWith act =<< mkRibCliConfig notesDir ribCfg
+      runRib act notesDir ribCfg
   where
-    oneOffCfg = do
-      cfg <- mkRibCliConfig notesDir $ RibConfig Nothing False Nothing
-      pure $
-        cfg
-          { Rib.Cli.verbosity = Silent
-          }
     execScript scriptPath args =
       -- We must use the low-level execvp (via the unix package's `executeFile`)
       -- here, such that the new process replaces the current one. fzf won't work

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -84,7 +84,7 @@ mkRibCliConfig inputDir =
       serve = Nothing
       verbosity = Verbose
       shakeDbDir = neuronDir </> ".shake"
-      watchIgnore = [".neuron"]
+      watchIgnore = [".neuron", ".git"]
    in Rib.Cli.CliConfig {..}
 
 -- | optparse-applicative parser for neuron CLI

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -27,6 +27,7 @@ import Relude
 import qualified Rib
 import System.Directory
 import System.FilePath
+import System.Info (os)
 import qualified System.Posix.Env as Env
 import System.Posix.Process
 import System.Which
@@ -56,6 +57,12 @@ runWith act App {..} = do
     New newCommand ->
       runRibOnceQuietly notesDir $ do
         newZettelFile newCommand
+    Open ->
+      runRibOnceQuietly notesDir $ do
+        indexHtmlPath <- fmap (</> "index.html") Rib.ribOutputDir
+        putStrLn indexHtmlPath
+        let opener = if os == "darwin" then "open" else "xdg-open"
+        liftIO $ executeFile opener True [indexHtmlPath] Nothing
     Query queries -> do
       runRibOnceQuietly notesDir $ do
         store <- Z.mkZettelStore =<< Rib.forEvery ["*.md"] pure

--- a/src/Neuron/Zettelkasten.hs
+++ b/src/Neuron/Zettelkasten.hs
@@ -144,13 +144,19 @@ runWith act App {..} = do
       execScript neuronSearchScript [notesDir]
     Query queries -> do
       cfg <- mkRibCliConfig notesDir
-      flip Rib.App.runWith (cfg {Rib.Cli.verbosity = Silent}) $ do
+      flip Rib.App.runWith (oneOffCfg cfg) $ do
         store <- Z.mkZettelStore =<< Rib.forEvery ["*.md"] pure
         let matches = Z.runQuery store queries
         putLTextLn $ Aeson.encodeToLazyText $ matches
     Rib ->
       Rib.App.runWith act =<< mkRibCliConfig notesDir
   where
+    oneOffCfg cfg =
+      cfg
+        { Rib.Cli.verbosity = Silent,
+          Rib.Cli.watch = False,
+          Rib.Cli.serve = Nothing
+        }
     execScript scriptPath args =
       -- We must use the low-level execvp (via the unix package's `executeFile`)
       -- here, such that the new process replaces the current one. fzf won't work

--- a/src/Neuron/Zettelkasten/CLI.hs
+++ b/src/Neuron/Zettelkasten/CLI.hs
@@ -40,6 +40,8 @@ data NewCommand = NewCommand {title :: Text, edit :: Bool}
 data Command
   = -- | Create a new zettel file
     New NewCommand
+  | -- | Open the locally generated Zettelkasten
+    Open
   | -- | Search a zettel by title
     Search
   | -- | Run a query against the Zettelkasten
@@ -79,7 +81,7 @@ runRibOnceQuietly :: FilePath -> Action () -> IO ()
 runRibOnceQuietly notesDir act =
   runRib act notesDir $
     RibConfig
-      { ribOutputDir = Nothing,
+      { ribOutputDir = Nothing, -- Ignoring CLI's output dir. So don't use this within `neuron rib ...`.
         ribWatch = False,
         ribServe = Nothing,
         ribQuiet = True
@@ -101,6 +103,7 @@ commandParser defaultNotesDir = do
       hsubparser $
         mconcat
           [ command "new" $ info newCommand $ progDesc "Create a new zettel",
+            command "open" $ info openCommand $ progDesc "Open the locally generated Zettelkasten website",
             command "search" $ info searchCommand $ progDesc "Search zettels and print the matching filepath",
             command "query" $ info queryCommand $ progDesc "Run a query against the zettelkasten",
             command "rib" $ info ribCommand $ progDesc "Generate static site via rib"
@@ -109,6 +112,8 @@ commandParser defaultNotesDir = do
       edit <- switch (long "edit" <> short 'e' <> help "Open the newly-created file in $EDITOR")
       title <- argument str (metavar "TITLE" <> help "Title of the new Zettel")
       return (New NewCommand {..})
+    openCommand =
+      pure Open
     queryCommand =
       fmap Query $
         (many (Z.ByTag <$> option str (long "tag" <> short 't')))

--- a/src/Neuron/Zettelkasten/CLI.hs
+++ b/src/Neuron/Zettelkasten/CLI.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.CLI
+  ( -- * CLI
+    App (..),
+    Command (..),
+    NewCommand (..),
+    commandParser,
+    runRib,
+    runRibOnceQuietly,
+  )
+where
+
+import Development.Shake (Action, Verbosity (Verbose))
+import qualified Neuron.Zettelkasten.Link.Action as Z
+import qualified Neuron.Zettelkasten.Query as Z
+import Options.Applicative
+import Relude
+import qualified Rib.App
+import qualified Rib.Cli
+import System.Directory
+import System.FilePath
+import qualified Text.URI as URI
+
+data App
+  = App
+      { notesDir :: FilePath,
+        cmd :: Command
+      }
+  deriving (Eq, Show)
+
+data NewCommand = NewCommand {title :: Text, edit :: Bool}
+  deriving (Eq, Show)
+
+data Command
+  = -- | Create a new zettel file
+    New NewCommand
+  | -- | Search a zettel by title
+    Search
+  | -- | Run a query against the Zettelkasten
+    Query [Z.Query]
+  | -- | Delegate to Rib's command parser
+    Rib RibConfig
+  deriving (Eq, Show)
+
+data RibConfig
+  = RibConfig
+      { ribOutputDir :: Maybe FilePath,
+        ribWatch :: Bool,
+        ribServe :: Maybe (Text, Int),
+        ribQuiet :: Bool
+      }
+  deriving (Eq, Show)
+
+mkRibCliConfig :: FilePath -> RibConfig -> IO Rib.Cli.CliConfig
+mkRibCliConfig inputDir cfg = do
+  unlessM (doesDirectoryExist inputDir) $ do
+    fail $ "Zettelkasten directory " <> inputDir <> " does not exist."
+  let neuronDir = inputDir </> ".neuron"
+      outputDir = fromMaybe (neuronDir </> "output") $ ribOutputDir cfg
+      rebuildAll = True
+      watch = ribWatch cfg
+      serve = ribServe cfg
+      verbosity = Verbose
+      shakeDbDir = neuronDir </> ".shake"
+      watchIgnore = [".neuron", ".git"]
+  pure Rib.Cli.CliConfig {..}
+
+runRib :: Action () -> FilePath -> RibConfig -> IO ()
+runRib act notesDir ribCfg =
+  Rib.App.runWith act =<< mkRibCliConfig notesDir ribCfg
+
+runRibOnceQuietly :: FilePath -> Action () -> IO ()
+runRibOnceQuietly notesDir act =
+  runRib act notesDir $
+    RibConfig
+      { ribOutputDir = Nothing,
+        ribWatch = False,
+        ribServe = Nothing,
+        ribQuiet = True
+      }
+
+-- | optparse-applicative parser for neuron CLI
+commandParser :: FilePath -> Parser App
+commandParser defaultNotesDir = do
+  notesDir <-
+    option
+      Rib.Cli.directoryReader
+      ( long "zettelkasten-dir" <> short 'd' <> metavar "NOTESDIR" <> value defaultNotesDir
+          <> help ("Your zettelkasten directory containing the zettel files (" <> "default: " <> defaultNotesDir <> ")")
+      )
+  cmd <- cmdParser
+  pure $ App {..}
+  where
+    cmdParser =
+      hsubparser $
+        mconcat
+          [ command "new" $ info newCommand $ progDesc "Create a new zettel",
+            command "search" $ info searchCommand $ progDesc "Search zettels and print the matching filepath",
+            command "query" $ info queryCommand $ progDesc "Run a query against the zettelkasten",
+            command "rib" $ info ribCommand $ progDesc "Generate static site via rib"
+          ]
+    newCommand = do
+      edit <- switch (long "edit" <> short 'e' <> help "Open the newly-created file in $EDITOR")
+      title <- argument str (metavar "TITLE" <> help "Title of the new Zettel")
+      return (New NewCommand {..})
+    queryCommand =
+      fmap Query $
+        (many (Z.ByTag <$> option str (long "tag" <> short 't')))
+          <|> (Z.queryFromUri . mkURIMust <$> option str (long "uri" <> short 'u'))
+    searchCommand =
+      pure Search
+    ribCommand = fmap Rib $ do
+      ribOutputDir <-
+        optional $
+          option
+            Rib.Cli.directoryReader
+            ( long "output-dir" <> short 'o' <> metavar "OUTPUTDIR"
+                <> help ("The directory where HTML will be generated (" <> "default: NOTESDIR/.neuron/output)")
+            )
+      ribWatch <- Rib.Cli.watchOption
+      ribServe <- Rib.Cli.serveOption
+      ~(ribQuiet) <- pure False
+      pure RibConfig {..}
+    mkURIMust =
+      either (error . toText . displayException) id . URI.mkURI

--- a/src/Neuron/Zettelkasten/CLI.hs
+++ b/src/Neuron/Zettelkasten/CLI.hs
@@ -16,7 +16,7 @@ module Neuron.Zettelkasten.CLI
   )
 where
 
-import Development.Shake (Action, Verbosity (Verbose))
+import Development.Shake (Action, Verbosity (Silent, Verbose))
 import qualified Neuron.Zettelkasten.Link.Action as Z
 import qualified Neuron.Zettelkasten.Query as Z
 import Options.Applicative
@@ -69,7 +69,7 @@ mkRibCliConfig inputDir cfg = do
       rebuildAll = True
       watch = ribWatch cfg
       serve = ribServe cfg
-      verbosity = Verbose
+      verbosity = bool Verbose Silent $ ribQuiet cfg
       shakeDbDir = fromMaybe (neuronDir </> ".shake") $ ribShakeDbDir cfg
       watchIgnore = [".neuron", ".git"]
   pure Rib.Cli.CliConfig {..}

--- a/src/Neuron/Zettelkasten/Config.hs
+++ b/src/Neuron/Zettelkasten/Config.hs
@@ -21,10 +21,10 @@ import Development.Shake (Action, readFile')
 import Dhall (FromDhall)
 import qualified Dhall
 import Dhall.TH
-import Path
-import Path.IO (doesFileExist)
 import Relude
 import qualified Rib
+import System.Directory
+import System.FilePath
 
 -- | Config type for @neuron.dhall@
 --
@@ -45,9 +45,9 @@ getConfig :: Action Config
 getConfig = do
   inputDir <- Rib.ribInputDir
   let configPath = inputDir </> configFile
-  configVal :: Text <- doesFileExist configPath >>= \case
+  configVal :: Text <- liftIO (doesFileExist configPath) >>= \case
     True -> do
-      userConfig <- fmap toText $ readFile' $ toFilePath configPath
+      userConfig <- fmap toText $ readFile' configPath
       -- Dhall's combine operator (`//`) allows us to merge two records,
       -- effectively merging the record with defaults with the user record.
       pure $ decodeUtf8 defaultConfig <> " // " <> userConfig
@@ -55,4 +55,4 @@ getConfig = do
       pure $ decodeUtf8 @Text defaultConfig
   liftIO $ Dhall.detailed $ Dhall.input Dhall.auto configVal
   where
-    configFile = [relfile|neuron.dhall|]
+    configFile = "neuron.dhall"

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -20,8 +20,10 @@ where
 import Data.Aeson (ToJSON)
 import qualified Data.Text as T
 import Data.Time
+import Development.Shake (Action)
 import Lucid
 import Relude
+import qualified Rib
 import System.Directory (listDirectory)
 import System.FilePath
 import qualified System.FilePattern as FP
@@ -66,10 +68,11 @@ zettelIDDate =
       Nothing ->
         error "Bad day"
 
-zettelNextIdForToday :: FilePath -> IO ZettelID
-zettelNextIdForToday inputDir = ZettelID <$> do
-  zIdPartial <- dayIndex . toText . formatTime defaultTimeLocale "%y%W%a" <$> getCurrentTime
-  zettelFiles <- listDirectory $ inputDir
+zettelNextIdForToday :: Action ZettelID
+zettelNextIdForToday = ZettelID <$> do
+  inputDir <- Rib.ribInputDir
+  zIdPartial <- dayIndex . toText . formatTime defaultTimeLocale "%y%W%a" <$> liftIO getCurrentTime
+  zettelFiles <- liftIO $ listDirectory inputDir
   let nums :: [Int] = sort $ catMaybes $ fmap readMaybe $ catMaybes $ catMaybes $ fmap (fmap listToMaybe . FP.match (toString zIdPartial <> "*.md")) zettelFiles
   case fmap last (nonEmpty nums) of
     Just lastNum ->

--- a/src/Neuron/Zettelkasten/Route.hs
+++ b/src/Neuron/Zettelkasten/Route.hs
@@ -18,7 +18,6 @@ import Neuron.Zettelkasten.Graph
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Store
 import Neuron.Zettelkasten.Zettel
-import Path
 import Relude
 import Rib (IsRoute (..))
 import Rib.Extra.OpenGraph
@@ -33,11 +32,11 @@ data Route store graph a where
 instance IsRoute (Route store graph) where
   routeFile = \case
     Route_IndexRedirect ->
-      pure [relfile|index.html|]
+      pure "index.html"
     Route_ZIndex ->
-      pure [relfile|z-index.html|]
+      pure "z-index.html"
     Route_Zettel (unZettelID -> zid) ->
-      parseRelFile $ toString zid <> ".html"
+      pure $ toString zid <> ".html"
 
 -- | Return short name corresponding to the route
 routeName :: Route store graph a -> Text

--- a/src/Neuron/Zettelkasten/Store.hs
+++ b/src/Neuron/Zettelkasten/Store.hs
@@ -15,14 +15,13 @@ import qualified Data.Map.Strict as Map
 import Development.Shake (Action)
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Zettel
-import Path
 import Relude
 import Rib (MMark)
 
 type ZettelStore = Map ZettelID (Zettel MMark)
 
 -- | Load all zettel files
-mkZettelStore :: [Path Rel File] -> Action ZettelStore
+mkZettelStore :: [FilePath] -> Action ZettelStore
 mkZettelStore files = do
   zettels <- mkZettelFromPath `mapM` files
   pure $ Map.fromList $ zettels <&> zettelID &&& id

--- a/src/Neuron/Zettelkasten/Zettel.hs
+++ b/src/Neuron/Zettelkasten/Zettel.hs
@@ -11,7 +11,6 @@ import Data.Aeson
 import Development.Shake (Action)
 import Neuron.Zettelkasten.ID
 import qualified Neuron.Zettelkasten.Meta as Meta
-import Path
 import Relude hiding (show)
 import qualified Rib.Parser.MMark as MMark
 import Text.MMark (MMark)
@@ -45,14 +44,14 @@ instance ToJSON (Zettel ()) where
       ]
 
 -- | Load a zettel from a file.
-mkZettelFromPath :: Path Rel File -> Action (Zettel MMark)
+mkZettelFromPath :: FilePath -> Action (Zettel MMark)
 mkZettelFromPath path = do
   -- Extensions are computed and applied during rendering, not here.
   let noExts = []
   doc <- MMark.parseWith noExts path
   let zid = mkZettelID path
       meta = Meta.getMeta doc
-      title = maybe (toText $ "No title for " <> toFilePath path) Meta.title meta
+      title = maybe (toText $ "No title for " <> path) Meta.title meta
       tags = fromMaybe [] $ Meta.tags =<< meta
   pure $ Zettel zid title tags doc
 

--- a/test/Neuron/VersionSpec.hs
+++ b/test/Neuron/VersionSpec.hs
@@ -21,14 +21,19 @@ spec = do
       pending
   -- TODO: Check minVersion in Default.dhall is same as the one in Paths_neuron
   describe "Version comparison" $ do
+    let isGreater = shouldSatisfy
+        isLesserOrEqual = shouldNotSatisfy
     it "must compare simple versions" $ do
-      "0.4" `shouldSatisfy` olderThan
-      "0.3" `shouldNotSatisfy` olderThan -- This is current version
-      "0.2" `shouldNotSatisfy` olderThan
+      -- If the user requires 0.4, and we are "older than" than that, fail (aka. isGreater)
+      "0.4" `isGreater` olderThan
+      "0.3" `isLesserOrEqual` olderThan -- This is current version
+      "0.2" `isLesserOrEqual` olderThan
     it "must compare full versions" $ do
-      "0.4.1.2" `shouldSatisfy` olderThan
-      "0.4.3" `shouldSatisfy` olderThan
-      "0.3.0.0" `shouldNotSatisfy` olderThan -- This is current version
-      "0.2.1.0" `shouldNotSatisfy` olderThan
+      "0.4.1.2" `isGreater` olderThan
+      "0.4.3" `isGreater` olderThan
+      "0.3.0.8" `isGreater` olderThan
+      "0.3.0.1" `isLesserOrEqual` olderThan -- This is current version
+      "0.2.1.0" `isLesserOrEqual` olderThan
     it "must compare within same major version" $ do
-      "0.3.0.2" `shouldSatisfy` olderThan -- This is current version
+      "0.3.0.8" `isGreater` olderThan
+      "0.3.0.1" `isLesserOrEqual` olderThan -- This is current version

--- a/test/Neuron/Zettelkasten/IDSpec.hs
+++ b/test/Neuron/Zettelkasten/IDSpec.hs
@@ -9,7 +9,6 @@ where
 
 import Data.Time.Calendar
 import qualified Neuron.Zettelkasten.ID as Z
-import Path
 import Relude
 import Test.Hspec
 
@@ -21,7 +20,7 @@ spec = do
       it "parses a zettel ID" $ do
         Z.parseZettelID "2011401" `shouldBe` zid
       it "parses a zettel ID from zettel filename" $ do
-        Z.mkZettelID [relfile|2011401.md|] `shouldBe` zid
+        Z.mkZettelID "2011401.md" `shouldBe` zid
         Z.zettelIDSourceFileName zid `shouldBe` "2011401.md"
       it "returns the correct day" $ do
         Z.zettelIDDate zid `shouldBe` fromGregorian 2020 3 19


### PR DESCRIPTION
- [x] Advance to newer rib with revamped CLI
- [x] Resolves #78 
- [x] Resolves #76 
- [x] Resolves #77
- [x] Change CLI to be of the form: `neuron -d ~/zettelkasten <cmd>`
- [x] Handle rib's cli args
  - [x] `neuron -d ~/zettelkasten rib -ws :8080` for serving (discard the `s :8080` to watch and generate only).
  - [x] `neuron -d ... rib --output=/tmp/output` to override output directory
- [x] Refactor CLI code
- [x] Add `neuron open` to open the locally generated output, using `xdg-open` on Linux and `open` on mac.
- [x] Update docs & test
