### PR TITLE
Support short links

### DIFF
--- a/guide/2011406.md
+++ b/guide/2011406.md
@@ -7,14 +7,14 @@ tags:
 You may use any text editor with Markdown support to edit your zettel files. Neuron provides a command to create new zettel files with the suitable [2011403](zcf://zettel-id):
 
 ```bash
-neuron -e ~/notes new "My zettel title"
+neuron -d ~/notes new "My zettel title"
 ```
 
 This command will print the path to the file created. Use `-e` to also open the text editor:
 
 
 ```bash
-neuron -e ~/notes new "My zettel title" -e
+neuron -d ~/notes new "My zettel title" -e
 ```
 
 Newly created zettels will be a cluster of its own (see [2012301](z://cluster)) until you connect other zettels to them.

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -5,19 +5,20 @@ title: Linking
 To link to another zettel, use the following syntax:
 
 ```markdown
-This is a zettel file, which links to another zettel: 
+This is a zettel file, which links to another zettel:
 
-- [2008403](z:). 
+- [2008403](z:).
 
-You may also annotate the link (ignored by neuron): 
+You may also annotate the link (ignored by neuron):
 
-- [2008403](z://foo-bar). 
+- [2008403](z://foo-bar).
 ```
 
 The `z:` protocol instructs neuron to automatically create a link between the associated zettels, which ultimately affects your zettel graph. Neuron also renders the link along with the ID and title of the linked zettel.
 
-If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view). 
+If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view).
 
 ## Other link types
 
 * [2011506](z://zquery)
+* [2014501](z://short-links)

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -5,18 +5,18 @@ title: Linking
 To link to another zettel, use the following syntax:
 
 ```markdown
-This is a zettel file, which links to another zettel: 
+This is a zettel file, which links to another zettel:
 
-- [2008403](z:). 
+- <2008403>.
 
-You may also annotate the link (ignored by neuron): 
+You may also annotate the link (ignored by neuron):
 
-- [2008403](z://foo-bar). 
+- [foo-bar](2008403).
 ```
 
 The `z:` protocol instructs neuron to automatically create a link between the associated zettels, which ultimately affects your zettel graph. Neuron also renders the link along with the ID and title of the linked zettel.
 
-If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view). 
+If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `[2008403](zcf://)` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view).
 
 ## Other link types
 

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -5,18 +5,18 @@ title: Linking
 To link to another zettel, use the following syntax:
 
 ```markdown
-This is a zettel file, which links to another zettel:
+This is a zettel file, which links to another zettel: 
 
-- <2008403>.
+- [2008403](z:). 
 
-You may also annotate the link (ignored by neuron):
+You may also annotate the link (ignored by neuron): 
 
-- [foo-bar](2008403).
+- [2008403](z://foo-bar). 
 ```
 
 The `z:` protocol instructs neuron to automatically create a link between the associated zettels, which ultimately affects your zettel graph. Neuron also renders the link along with the ID and title of the linked zettel.
 
-If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `[2008403](zcf://)` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view).
+If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view). 
 
 ## Other link types
 

--- a/guide/2014501.md
+++ b/guide/2014501.md
@@ -1,0 +1,18 @@
+---
+title: Short links
+---
+
+You can write
+```markdown
+<2008403>
+```
+
+instead of
+
+```markdown
+[2008403](z:)
+```
+
+to link to a zettel. This is an experimental feature that will probably be
+extended to support other types of links.
+See [this GitHub issue](https://github.com/srid/neuron/issues/59) for details.

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -43,6 +43,7 @@ common library-common
     lucid -any,
     optparse-applicative,
     pandoc,
+    regex-tdfa,
     relude,
     rib ^>=0.9,
     shake -any,

--- a/src/Neuron/Zettelkasten/Link.hs
+++ b/src/Neuron/Zettelkasten/Link.hs
@@ -29,7 +29,7 @@ linkActionExt store =
       let mlink = MarkdownLink (Ext.asPlainText inner) uri
        in case linkActionFromLink mlink of
             Just lact ->
-               linkActionRender store mlink lact
+              linkActionRender store mlink lact
             Nothing ->
               f inline
     inline ->

--- a/src/Neuron/Zettelkasten/Link.hs
+++ b/src/Neuron/Zettelkasten/Link.hs
@@ -26,11 +26,11 @@ linkActionExt :: ZettelStore -> Extension
 linkActionExt store =
   Ext.inlineRender $ \f -> \case
     inline@(Link inner uri _title) ->
-      case linkActionFromUri uri of
-        Just lact ->
-          let mlink = MarkdownLink (Ext.asPlainText inner) uri
-           in linkActionRender store mlink lact
-        Nothing ->
-          f inline
+      let mlink = MarkdownLink (Ext.asPlainText inner) uri
+       in case linkActionFromLink mlink of
+            Just lact ->
+               linkActionRender store mlink lact
+            Nothing ->
+              f inline
     inline ->
       f inline

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -35,7 +35,6 @@ data LinkTheme
 data LinkAction
   = LinkAction_ConnectZettel Connection ZettelID
   | -- | Render a list (or should it be tree?) of links to queries zettels
-    -- TODO: Should this automatically establish a connection in graph??
     LinkAction_QueryZettels Connection LinkTheme [Query]
   deriving (Eq, Show)
 

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -25,6 +25,7 @@ import Text.MMark (MMark, runScanner)
 import qualified Text.MMark.Extension as Ext
 import Text.MMark.Extension (Inline (..))
 import qualified Text.URI as URI
+import Text.Regex.TDFA ((=~))
 
 data LinkTheme
   = LinkTheme_Default
@@ -55,6 +56,9 @@ linkActionFromLink MarkdownLink {markdownLinkUri=uri,markdownLinkText=text} =
       Just $ LinkAction_QueryZettels Folgezettel (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
     Just "zcfquery" ->
       Just $ LinkAction_QueryZettels OrdinaryConnection (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
+    _ | URI.render uri =~ ("^[A-Za-z0-9_-]+$" :: Text) ->
+      let zid = parseZettelID $ URI.render uri
+       in Just $ LinkAction_ConnectZettel Folgezettel zid
     _ ->
       Nothing
 

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -24,8 +24,8 @@ import Relude
 import Text.MMark (MMark, runScanner)
 import qualified Text.MMark.Extension as Ext
 import Text.MMark.Extension (Inline (..))
-import qualified Text.URI as URI
 import Text.Regex.TDFA ((=~))
+import qualified Text.URI as URI
 
 data LinkTheme
   = LinkTheme_Default
@@ -40,7 +40,7 @@ data LinkAction
   deriving (Eq, Show)
 
 linkActionFromLink :: MarkdownLink -> Maybe LinkAction
-linkActionFromLink MarkdownLink {markdownLinkUri=uri,markdownLinkText=text} =
+linkActionFromLink MarkdownLink {markdownLinkUri = uri, markdownLinkText = text} =
   -- NOTE: We should probably drop the 'cf' variants in favour of specifying
   -- the connection type as a query param or something.
   case fmap URI.unRText (URI.uriScheme uri) of
@@ -56,9 +56,10 @@ linkActionFromLink MarkdownLink {markdownLinkUri=uri,markdownLinkText=text} =
       Just $ LinkAction_QueryZettels Folgezettel (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
     Just "zcfquery" ->
       Just $ LinkAction_QueryZettels OrdinaryConnection (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
-    _ | URI.render uri =~ ("^[A-Za-z0-9_-]+$" :: Text) ->
-      let zid = parseZettelID $ URI.render uri
-       in Just $ LinkAction_ConnectZettel Folgezettel zid
+    _
+      | URI.render uri =~ ("^[A-Za-z0-9_-]+$" :: Text) ->
+        let zid = parseZettelID $ URI.render uri
+         in Just $ LinkAction_ConnectZettel Folgezettel zid
     _ ->
       Nothing
 

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -56,12 +56,14 @@ linkActionFromLink MarkdownLink {markdownLinkUri = uri, markdownLinkText = text}
       Just $ LinkAction_QueryZettels Folgezettel (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
     Just "zcfquery" ->
       Just $ LinkAction_QueryZettels OrdinaryConnection (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
-    _
-      | URI.render uri =~ ("^[A-Za-z0-9_-]+$" :: Text) ->
-        let zid = parseZettelID $ URI.render uri
-         in Just $ LinkAction_ConnectZettel Folgezettel zid
     _ ->
-      Nothing
+      let uri_text = URI.render uri
+       in if uri_text =~ ("^[A-Za-z0-9_-]+$" :: Text)
+            && uri_text == text
+            then
+              let zid = parseZettelID uri_text
+               in Just $ LinkAction_ConnectZettel Folgezettel zid
+            else Nothing
 
 queryFromUri :: URI.URI -> [Query]
 queryFromUri uri =

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -25,10 +25,8 @@ import Relude
 import qualified Rib
 
 linkActionRender :: Monad m => ZettelStore -> MarkdownLink -> LinkAction -> HtmlT m ()
-linkActionRender store MarkdownLink {..} = \case
-  LinkAction_ConnectZettel _conn -> do
-    -- The inner link text is supposed to be the zettel ID
-    let zid = parseZettelID markdownLinkText
+linkActionRender store _ = \case
+  LinkAction_ConnectZettel _conn zid -> do
     renderZettelLink LinkTheme_Default store zid
   LinkAction_QueryZettels _conn linkTheme q -> do
     toHtmlRaw @Text $ "<!--" <> show q <> "-->"


### PR DESCRIPTION
This adds support for short `<1234567>` links, as discussed in #59. In fact what this does is render any `[foo](1234567)` link as a zettel link. That can easily be changed if needed.

Some questions: where should I document this ? Do you use a Haskell formatter and if yes which one ?