### PR TITLE
Explicit ID scheme

### DIFF
--- a/guide/2011403.md
+++ b/guide/2011403.md
@@ -11,3 +11,12 @@ Neuron uses weekdays in IDs. Consider the following zettel ID: `2008306`. It is 
 The first two letters, `20`, represent the year (and I'll have to live beyond age 135 to run out of space here!). The next two, `08`, represent the [week number](https://en.wikipedia.org/wiki/ISO_week_date) of the year. The subsequent letter, `3`, which can be anything from `1` to `7`, represents the week day. Finally, the last two letters represent the n'th note taken in that day.
 
 The above example corresponds to the note file `2008306.md` on disk.
+
+## Custom ID
+
+A neuron Zettel ID is typically of the form described above. However a custom ID is supported as long as it contains only the following characters:
+
+* alphabets 
+* digits
+* hyphen (`-`)
+* underscore (`_`)

--- a/guide/2011501.md
+++ b/guide/2011501.md
@@ -23,9 +23,7 @@ cachix use srid
 
 ## Install neuron
 
-To install the last stable version of neuron, run:
-
-If you prefer the latest development version of neuron, run instead:
+To install the latest development version of neuron, run:
 
 ```bash
 nix-env -iE '_: let src = builtins.fetchGit { url = "https://github.com/srid/neuron"; ref = "master"; }; in import src.outPath { gitRev = src.shortRev; }' --option tarball-ttl 0

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -43,7 +43,6 @@ common library-common
     lucid -any,
     optparse-applicative,
     pandoc,
-    regex-tdfa,
     relude,
     rib ^>=0.9,
     shake -any,

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -58,7 +58,8 @@ common library-common
     algebraic-graphs >= 0.5,
     dhall >= 1.30,
     which,
-    unix
+    unix,
+    megaparsec >= 8.0
 
 library
   import: library-common

--- a/src/Neuron/Zettelkasten/Graph.hs
+++ b/src/Neuron/Zettelkasten/Graph.hs
@@ -72,11 +72,6 @@ backlinks zid =
 topSort :: ZettelGraph -> Either (NonEmpty ZettelID) [ZettelID]
 topSort = Algo.topSort . LAM.skeleton
 
--- | Get the graph without the "index" zettel.
--- This is unused, but left for posterity.
-_withoutIndex :: ZettelGraph -> ZettelGraph
-_withoutIndex = LAM.induce ((/= "index") . unZettelID)
-
 zettelClusters :: ZettelGraph -> [NonEmpty ZettelID]
 zettelClusters = mothers . LAM.skeleton
 

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -8,8 +11,8 @@
 module Neuron.Zettelkasten.ID
   ( ZettelID (..),
     Connection (..),
-    ZettelConnection,
-    zettelIDDate,
+    zettelIDDay,
+    zettelIDText,
     parseZettelID,
     mkZettelID,
     zettelNextIdForToday,
@@ -27,60 +30,33 @@ import qualified Rib
 import System.Directory (listDirectory)
 import System.FilePath
 import qualified System.FilePattern as FP
+import qualified Text.Megaparsec as M
+import qualified Text.Megaparsec.Char as M
 import Text.Printf
 
 -- | Short Zettel ID encoding `Day` and a numeric index (on that day).
 --
 -- Based on https://old.reddit.com/r/Zettelkasten/comments/fa09zw/shorter_zettel_ids/
-newtype ZettelID = ZettelID {unZettelID :: Text}
-  deriving (Eq, Show, Ord, ToJSON)
+data ZettelID
+  = ZettelDateID Day Int
+  | ZettelCustomID Text
+  deriving (Eq, Show, Ord, Generic, ToJSON)
 
 instance ToHtml ZettelID where
   toHtmlRaw = toHtml
-  toHtml = toHtml . unZettelID
+  toHtml = toHtml . zettelIDText
 
-zettelIDSourceFileName :: ZettelID -> Text
-zettelIDSourceFileName zid = unZettelID zid <> ".md"
+zettelIDText :: ZettelID -> Text
+zettelIDText = \case
+  ZettelDateID day idx ->
+    formatDay day <> toText @String (printf "%02d" idx)
+  ZettelCustomID s -> s
 
--- TODO: sync/DRY with zettelNextIdForToday
-zettelIDDate :: ZettelID -> Day
-zettelIDDate =
-  parseTimeOrError False defaultTimeLocale "%y%W%a"
-    . toString
-    . uncurry mappend
-    . second (dayFromIndex . readMaybe . toString)
-    . (T.dropEnd 1 &&& T.takeEnd 1)
-    . T.dropEnd 2
-    . unZettelID
+formatDay :: Day -> Text
+formatDay day =
+  subDay $ toText $ formatTime defaultTimeLocale "%y%W%a" day
   where
-    dayFromIndex :: Maybe Int -> Text
-    dayFromIndex = \case
-      Just n ->
-        case n of
-          1 -> "Mon"
-          2 -> "Tue"
-          3 -> "Wed"
-          4 -> "Thu"
-          5 -> "Fri"
-          6 -> "Sat"
-          7 -> "Sun"
-          _ -> error "> 7"
-      Nothing ->
-        error "Bad day"
-
-zettelNextIdForToday :: Action ZettelID
-zettelNextIdForToday = ZettelID <$> do
-  inputDir <- Rib.ribInputDir
-  zIdPartial <- dayIndex . toText . formatTime defaultTimeLocale "%y%W%a" <$> liftIO getCurrentTime
-  zettelFiles <- liftIO $ listDirectory inputDir
-  let nums :: [Int] = sort $ catMaybes $ fmap readMaybe $ catMaybes $ catMaybes $ fmap (fmap listToMaybe . FP.match (toString zIdPartial <> "*.md")) zettelFiles
-  case fmap last (nonEmpty nums) of
-    Just lastNum ->
-      pure $ zIdPartial <> toText @String (printf "%02d" $ lastNum + 1)
-    Nothing ->
-      pure $ zIdPartial <> "01"
-  where
-    dayIndex =
+    subDay =
       T.replace "Mon" "1"
         . T.replace "Tue" "2"
         . T.replace "Wed" "3"
@@ -89,17 +65,70 @@ zettelNextIdForToday = ZettelID <$> do
         . T.replace "Sat" "6"
         . T.replace "Sun" "7"
 
--- TODO: Actually parse and validate
+zettelIDSourceFileName :: ZettelID -> Text
+zettelIDSourceFileName zid = zettelIDText zid <> ".md"
+
+zettelIDDay :: ZettelID -> Maybe Day
+zettelIDDay = \case
+  ZettelCustomID _ -> Nothing
+  ZettelDateID day _ ->
+    Just day
+
+zettelNextIdForToday :: Action ZettelID
+zettelNextIdForToday = do
+  inputDir <- Rib.ribInputDir
+  day <- utctDay <$> liftIO getCurrentTime
+  let dayS = toString $ formatDay day
+  zettelFiles <- liftIO $ listDirectory inputDir
+  let nums :: [Int] = sort $ catMaybes $ fmap readMaybe $ catMaybes $ catMaybes $ fmap (fmap listToMaybe . FP.match (dayS <> "*.md")) zettelFiles
+  case fmap last (nonEmpty nums) of
+    Just lastNum ->
+      pure $ ZettelDateID day (lastNum + 1)
+    Nothing ->
+      pure $ ZettelDateID day 1
+
 parseZettelID :: Text -> ZettelID
-parseZettelID = ZettelID
+parseZettelID s =
+  either (error . toText . M.errorBundlePretty) id $
+    M.parse p "parseZettelID" s
+  where
+    p =
+      fmap (uncurry ZettelDateID) dayParser
+        <|> fmap ZettelCustomID customIDParser
+
+dayParser :: M.Parsec Void Text (Day, Int)
+dayParser = do
+  year <- parseNum 2
+  week <- parseNum 2
+  dayIdx <- parseNum 1
+  idx <- parseNum 2
+  day <-
+    parseTimeM False defaultTimeLocale "%y%W%a" $
+      printf "%02d" year <> printf "%02d" week <> toString (dayName dayIdx)
+  pure (day, idx)
+  where
+    parseNum n = readNum =<< M.count n M.digitChar
+    readNum = maybe (fail "Not a number") pure . readMaybe
+    dayName :: Int -> Text
+    dayName = \case
+      1 -> "Mon"
+      2 -> "Tue"
+      3 -> "Wed"
+      4 -> "Thu"
+      5 -> "Fri"
+      6 -> "Sat"
+      7 -> "Sun"
+      _ -> error "> 7"
+
+customIDParser :: M.Parsec Void Text Text
+customIDParser = do
+  fmap toText $ M.some $ M.alphaNumChar <|> M.char '_' <|> M.char '-'
 
 -- | Extract ZettelID from the zettel's filename or path.
 mkZettelID :: FilePath -> ZettelID
 mkZettelID fp =
   let (name, _) = splitExtension $ takeFileName fp
-   in ZettelID $ toText name
-
-type ZettelConnection = (Connection, ZettelID)
+   in parseZettelID $ toText name
 
 -- | Represent the connection between zettels
 data Connection

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -14,6 +14,7 @@ module Neuron.Zettelkasten.ID
     zettelIDDay,
     zettelIDText,
     parseZettelID,
+    parseZettelID',
     mkZettelID,
     zettelNextIdForToday,
     zettelIDSourceFileName,
@@ -88,9 +89,13 @@ zettelNextIdForToday = do
       pure $ ZettelDateID day 1
 
 parseZettelID :: Text -> ZettelID
-parseZettelID s =
-  either (error . toText . M.errorBundlePretty) id $
-    M.parse p "parseZettelID" s
+parseZettelID =
+  either error id . parseZettelID'
+
+parseZettelID' :: Text -> Either Text ZettelID
+parseZettelID' s =
+  first (toText . M.errorBundlePretty) $
+    M.parse (p <* M.eof) "parseZettelID" s
   where
     p =
       fmap (uncurry ZettelDateID) dayParser

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -55,12 +55,11 @@ linkActionFromLink MarkdownLink {markdownLinkUri = uri, markdownLinkText = linkT
       Just $ LinkAction_QueryZettels Folgezettel (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
     Just "zcfquery" ->
       Just $ LinkAction_QueryZettels OrdinaryConnection (fromMaybe LinkTheme_Default $ linkThemeFromUri uri) (queryFromUri uri)
-    _ ->
-      case parseZettelID' (URI.render uri) of
-        Right zid ->
-          Just $ LinkAction_ConnectZettel Folgezettel zid
-        Left _ ->
-          Nothing
+    _ -> do
+      let uriS = URI.render uri
+      guard $ uriS == linkText
+      zid <- rightToMaybe $ parseZettelID' uriS
+      pure $ LinkAction_ConnectZettel Folgezettel zid
 
 queryFromUri :: URI.URI -> [Query]
 queryFromUri uri =

--- a/src/Neuron/Zettelkasten/Link/Action.hs
+++ b/src/Neuron/Zettelkasten/Link/Action.hs
@@ -95,7 +95,7 @@ data MarkdownLink = MarkdownLink
   }
   deriving (Eq, Ord)
 
-linkActionConnections :: ZettelStore -> MarkdownLink -> [ZettelConnection]
+linkActionConnections :: ZettelStore -> MarkdownLink -> [(Connection, ZettelID)]
 linkActionConnections store link =
   case linkActionFromLink link of
     Just (LinkAction_ConnectZettel conn zid) ->

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -52,9 +52,14 @@ renderZettelLink ltheme store zid = do
       -- Uses ZettelID as link text. Title is displayed aside.
       renderDefault zid
     LinkTheme_WithDate -> do
-      renderDefault $ show @Text $ zettelIDDate zid
+      case zettelIDDay zid of
+        Just day ->
+          renderDefault $ show @Text day
+        Nothing ->
+          -- Fallback to using zid
+          renderDefault zid
     LinkTheme_Simple -> do
-      renderZettelLinkSimpleWith zurl (unZettelID zid) zettelTitle
+      renderZettelLinkSimpleWith zurl (zettelIDText zid) zettelTitle
 
 -- | Render a normal looking zettel link with a custom body.
 renderZettelLinkSimpleWith :: forall m a. (Monad m, ToHtml a) => Text -> Text -> a -> HtmlT m ()

--- a/src/Neuron/Zettelkasten/Route.hs
+++ b/src/Neuron/Zettelkasten/Route.hs
@@ -35,15 +35,15 @@ instance IsRoute (Route store graph) where
       pure "index.html"
     Route_ZIndex ->
       pure "z-index.html"
-    Route_Zettel (unZettelID -> zid) ->
-      pure $ toString zid <> ".html"
+    Route_Zettel (zettelIDText -> s) ->
+      pure $ toString s <> ".html"
 
 -- | Return short name corresponding to the route
 routeName :: Route store graph a -> Text
 routeName = \case
   Route_IndexRedirect -> "Index"
   Route_ZIndex -> "Zettels"
-  Route_Zettel zid -> unZettelID zid
+  Route_Zettel zid -> zettelIDText zid
 
 -- | Return full title for a route
 routeTitle :: Config -> store -> Route store graph a -> Text

--- a/src/Neuron/Zettelkasten/Store.hs
+++ b/src/Neuron/Zettelkasten/Store.hs
@@ -27,4 +27,4 @@ mkZettelStore files = do
   pure $ Map.fromList $ zettels <&> zettelID &&& id
 
 lookupStore :: ZettelID -> ZettelStore -> Zettel MMark
-lookupStore zid = fromMaybe (error $ "No such zettel: " <> unZettelID zid) . Map.lookup zid
+lookupStore zid = fromMaybe (error $ "No such zettel: " <> zettelIDText zid) . Map.lookup zid

--- a/src/Neuron/Zettelkasten/Store.hs
+++ b/src/Neuron/Zettelkasten/Store.hs
@@ -27,4 +27,4 @@ mkZettelStore files = do
   pure $ Map.fromList $ zettels <&> zettelID &&& id
 
 lookupStore :: ZettelID -> ZettelStore -> Zettel MMark
-lookupStore zid = fromMaybe (error $ "No such zettel: " <> zettelIDText zid) . Map.lookup zid
+lookupStore zid = fromMaybe (error $ "No such zettel: " <> show zid) . Map.lookup zid

--- a/src/Neuron/Zettelkasten/View.hs
+++ b/src/Neuron/Zettelkasten/View.hs
@@ -23,7 +23,7 @@ import Lucid
 import Neuron.Version (neuronVersionFull)
 import Neuron.Zettelkasten.Config
 import Neuron.Zettelkasten.Graph
-import Neuron.Zettelkasten.ID (ZettelID (..), zettelIDSourceFileName)
+import Neuron.Zettelkasten.ID (ZettelID (..), zettelIDSourceFileName, zettelIDText)
 import Neuron.Zettelkasten.Link (linkActionExt)
 import Neuron.Zettelkasten.Link.Action (LinkTheme (..))
 import Neuron.Zettelkasten.Link.View (renderZettelLink)
@@ -167,7 +167,7 @@ renderForest isRoot maxLevel ltheme s g trees =
                 -- Has two or more backlinks
                 forM_ conns $ \zid2 -> do
                   let z2 = lookupStore zid2 s
-                  i_ [class_ "fas fa-link", title_ $ unZettelID zid2 <> " " <> zettelTitle z2] mempty
+                  i_ [class_ "fas fa-link", title_ $ zettelIDText zid2 <> " " <> zettelTitle z2] mempty
               _ -> mempty
           when (length subtrees > 0) $ do
             ul_ $ renderForest False ((\n -> n - 1) <$> maxLevel) ltheme s g subtrees

--- a/test/Neuron/Zettelkasten/IDSpec.hs
+++ b/test/Neuron/Zettelkasten/IDSpec.hs
@@ -16,11 +16,12 @@ spec :: Spec
 spec = do
   describe "Zettel ID" $ do
     context "parsing" $ do
-      let zid = Z.ZettelID "2011401"
+      let day = fromGregorian 2020 3 19
+          zid = Z.ZettelDateID day 1
       it "parses a zettel ID" $ do
         Z.parseZettelID "2011401" `shouldBe` zid
       it "parses a zettel ID from zettel filename" $ do
         Z.mkZettelID "2011401.md" `shouldBe` zid
         Z.zettelIDSourceFileName zid `shouldBe` "2011401.md"
       it "returns the correct day" $ do
-        Z.zettelIDDate zid `shouldBe` fromGregorian 2020 3 19
+        Z.zettelIDDay zid `shouldBe` Just day

--- a/test/Neuron/Zettelkasten/Link/ActionSpec.hs
+++ b/test/Neuron/Zettelkasten/Link/ActionSpec.hs
@@ -50,6 +50,10 @@ linkActionCases =
     ( "zcfquery: link, with link theme",
       (Right (".", "zcfquery://search?tag=science&linkTheme=withDate")),
       Just $ LinkAction_QueryZettels OrdinaryConnection LinkTheme_WithDate [ByTag "science"]
+    ),
+    ( "normal link",
+      (Left "https://www.google.com"),
+      Nothing
     )
   ]
   where

--- a/test/Neuron/Zettelkasten/Link/ActionSpec.hs
+++ b/test/Neuron/Zettelkasten/Link/ActionSpec.hs
@@ -27,6 +27,10 @@ linkActionCases =
       (Left "1234567"),
       Just $ LinkAction_ConnectZettel Folgezettel zid
     ),
+    ( "not an alias link (different link text)",
+      (Right ("foo", "1234567")),
+      Nothing
+    ),
     ( "z: link",
       (Right ("1234567", "z:")),
       Just $ LinkAction_ConnectZettel Folgezettel zid

--- a/test/Neuron/Zettelkasten/Link/ActionSpec.hs
+++ b/test/Neuron/Zettelkasten/Link/ActionSpec.hs
@@ -7,7 +7,7 @@ module Neuron.Zettelkasten.Link.ActionSpec
   )
 where
 
-import Neuron.Zettelkasten.ID (Connection (..), ZettelID (..))
+import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link.Action
 import Neuron.Zettelkasten.Query
 import Relude
@@ -25,23 +25,23 @@ linkActionCases :: [(String, Either Text (Text, Text), Maybe LinkAction)]
 linkActionCases =
   [ ( "alias link",
       (Left "1234567"),
-      Just $ LinkAction_ConnectZettel Folgezettel (ZettelID "1234567")
+      Just $ LinkAction_ConnectZettel Folgezettel zid
     ),
     ( "z: link",
       (Right ("1234567", "z:")),
-      Just $ LinkAction_ConnectZettel Folgezettel (ZettelID "1234567")
+      Just $ LinkAction_ConnectZettel Folgezettel zid
     ),
     ( "z: link, with annotation ignored",
       (Right ("1234567", "z://foo-bar")),
-      Just $ LinkAction_ConnectZettel Folgezettel (ZettelID "1234567")
+      Just $ LinkAction_ConnectZettel Folgezettel zid
     ),
     ( "zcf: link",
       (Right ("1234567", "zcf:")),
-      Just $ LinkAction_ConnectZettel OrdinaryConnection (ZettelID "1234567")
+      Just $ LinkAction_ConnectZettel OrdinaryConnection zid
     ),
     ( "zcf: link, with annotation ignored",
       (Right ("1234567", "zcf://foo-bar")),
-      Just $ LinkAction_ConnectZettel OrdinaryConnection (ZettelID "1234567")
+      Just $ LinkAction_ConnectZettel OrdinaryConnection zid
     ),
     ( "zquery: link",
       (Right (".", "zquery://search?tag=science")),
@@ -52,6 +52,8 @@ linkActionCases =
       Just $ LinkAction_QueryZettels OrdinaryConnection LinkTheme_WithDate [ByTag "science"]
     )
   ]
+  where
+    zid = parseZettelID "1234567"
 
 mkMarkdownLink :: Text -> Text -> MarkdownLink
 mkMarkdownLink s l =


### PR DESCRIPTION
Allow either neuron's ID scheme, or a custom alphanumeric (with hyphen and underscore) scheme. Nothing else will be permitted in the zettel ID.

Resolves #70

- [x] Document the allowed ID scheme

