### PR TITLE
Nix derivation: accept pkgs as an arg

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,12 +13,12 @@ in {
 , name ? "neuron"
 , gitRev ? ""
 , source-overrides ? {}
+, pkgs ? import <nixpkgs> {}
 , ...
 }:
 
 let 
   inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
-  pkgs = import <nixpkgs> {};
   neuronSearchScript = pkgs.callPackage ./src-script/neuron-search { inherit pkgs; };
   additional-packages = pkgs:
   [ neuronSearchScript


### PR DESCRIPTION
This allows declarative installations to pin the nixpkgs version to
enable deterministic builds and overrides.