### PR TITLE
feat(website): Add MMark extension to render table with styles

### DIFF
--- a/src/Neuron/Zettelkasten/Markdown.hs
+++ b/src/Neuron/Zettelkasten/Markdown.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Neuron.Zettelkasten.Markdown
   ( neuronMMarkExts,
@@ -8,6 +7,7 @@ module Neuron.Zettelkasten.Markdown
 where
 
 import Neuron.Zettelkasten.Config (Config (..))
+import Neuron.Zettelkasten.Markdown.Extension (customRender)
 import Relude
 import qualified Text.MMark as MMark
 import qualified Text.MMark.Extension.Common as Ext
@@ -24,5 +24,6 @@ defaultExts =
     Ext.kbd,
     Ext.linkTarget,
     Ext.punctuationPrettifier,
-    Ext.skylighting
+    Ext.skylighting,
+    customRender
   ]

--- a/src/Neuron/Zettelkasten/Markdown.hs
+++ b/src/Neuron/Zettelkasten/Markdown.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Neuron.Zettelkasten.Markdown
@@ -7,7 +8,7 @@ module Neuron.Zettelkasten.Markdown
 where
 
 import Neuron.Zettelkasten.Config (Config (..))
-import Neuron.Zettelkasten.Markdown.Extension (customRender)
+import Neuron.Zettelkasten.Markdown.Extension (setTableClass)
 import Relude
 import qualified Text.MMark as MMark
 import qualified Text.MMark.Extension.Common as Ext
@@ -25,5 +26,5 @@ defaultExts =
     Ext.linkTarget,
     Ext.punctuationPrettifier,
     Ext.skylighting,
-    customRender
+    setTableClass "ui celled table"
   ]

--- a/src/Neuron/Zettelkasten/Markdown/Extension.hs
+++ b/src/Neuron/Zettelkasten/Markdown/Extension.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Neuron.Zettelkasten.Markdown.Extension
+  ( customRender,
+  )
+where
+
+import Control.Monad (forM_)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
+import Lucid
+import Text.MMark.Extension (Block (Table), Extension)
+import qualified Text.MMark.Extension as Ext
+
+newline :: Html ()
+newline = "\n"
+
+-- https://github.com/mmark-md/mmark/blob/8f5534d8068c2b7a139b893639ee5920bcaedd84/Text/MMark/Render.hs#L111-L136
+customRender :: Extension
+customRender = Ext.blockRender $ \old block ->
+  case block of
+    (Table calign (hs :| rows)) -> do
+      table_ [class_ "ui celled table"] $ do
+        newline
+        thead_ $ do
+          newline
+          tr_
+            $ forM_ (NE.zip calign hs)
+            $ \(a, h) ->
+              th_ (alignStyle a) (snd h)
+          newline
+        newline
+        tbody_ $ do
+          newline
+          forM_ rows $ \row -> do
+            tr_
+              $ forM_ (NE.zip calign row)
+              $ \(a, h) ->
+                td_ (alignStyle a) (snd h)
+            newline
+        newline
+      newline
+    other -> old other
+  where
+    alignStyle Ext.CellAlignDefault = []
+    alignStyle Ext.CellAlignLeft = [style_ "text-align:left"]
+    alignStyle Ext.CellAlignRight = [style_ "text-align:right"]
+    alignStyle Ext.CellAlignCenter = [style_ "text-align:center"]

--- a/src/Neuron/Zettelkasten/Markdown/Extension.hs
+++ b/src/Neuron/Zettelkasten/Markdown/Extension.hs
@@ -6,43 +6,13 @@ module Neuron.Zettelkasten.Markdown.Extension
   )
 where
 
-import qualified Data.List.NonEmpty as NE
 import Lucid
 import Relude
 import Text.MMark.Extension (Block (Table), Extension)
 import qualified Text.MMark.Extension as Ext
 
-newline :: Html ()
-newline = "\n"
-
 setTableClass :: Text -> Extension
 setTableClass tableClass = Ext.blockRender $ \old block ->
   case block of
-    -- https://github.com/mmark-md/mmark/blob/8f5534d8068c2b7a139b893639ee5920bcaedd84/Text/MMark/Render.hs#L111-L136
-    (Table calign (hs :| rows)) -> do
-      table_ [class_ tableClass] $ do
-        newline
-        thead_ $ do
-          newline
-          tr_
-            $ forM_ (NE.zip calign hs)
-            $ \(a, h) ->
-              th_ (alignStyle a) (snd h)
-          newline
-        newline
-        tbody_ $ do
-          newline
-          forM_ rows $ \row -> do
-            tr_
-              $ forM_ (NE.zip calign row)
-              $ \(a, h) ->
-                td_ (alignStyle a) (snd h)
-            newline
-        newline
-      newline
+    table@(Table _ _) -> with (old table) [class_ tableClass]
     other -> old other
-  where
-    alignStyle Ext.CellAlignDefault = []
-    alignStyle Ext.CellAlignLeft = [style_ "text-align:left"]
-    alignStyle Ext.CellAlignRight = [style_ "text-align:right"]
-    alignStyle Ext.CellAlignCenter = [style_ "text-align:center"]

--- a/src/Neuron/Zettelkasten/Markdown/Extension.hs
+++ b/src/Neuron/Zettelkasten/Markdown/Extension.hs
@@ -1,26 +1,26 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Neuron.Zettelkasten.Markdown.Extension
-  ( customRender,
+  ( setTableClass,
   )
 where
 
-import Control.Monad (forM_)
-import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Lucid
+import Relude
 import Text.MMark.Extension (Block (Table), Extension)
 import qualified Text.MMark.Extension as Ext
 
 newline :: Html ()
 newline = "\n"
 
--- https://github.com/mmark-md/mmark/blob/8f5534d8068c2b7a139b893639ee5920bcaedd84/Text/MMark/Render.hs#L111-L136
-customRender :: Extension
-customRender = Ext.blockRender $ \old block ->
+setTableClass :: Text -> Extension
+setTableClass tableClass = Ext.blockRender $ \old block ->
   case block of
+    -- https://github.com/mmark-md/mmark/blob/8f5534d8068c2b7a139b893639ee5920bcaedd84/Text/MMark/Render.hs#L111-L136
     (Table calign (hs :| rows)) -> do
-      table_ [class_ "ui celled table"] $ do
+      table_ [class_ tableClass] $ do
         newline
         thead_ $ do
           newline


### PR DESCRIPTION
Fixes #91 

This PR adds a MMark extension to render tables with classes.

### TODO

- [ ] Use Semantic UI classes for cell alignment?
- [ ] ...

### Screenshots

#### Before

<img width="736" alt="Screenshot 2020-04-13 at 19 53 57" src="https://user-images.githubusercontent.com/8309423/79145197-8b26f380-7dc0-11ea-9af4-2aca2e8c510a.png">

#### After

<img width="728" alt="Screenshot 2020-04-13 at 19 53 42" src="https://user-images.githubusercontent.com/8309423/79145191-895d3000-7dc0-11ea-8235-b7fa5ba598e9.png">