### PR TITLE
ZettelStore: more helpful lookup failure message

### DIFF
--- a/src/Neuron/Zettelkasten/Store.hs
+++ b/src/Neuron/Zettelkasten/Store.hs
@@ -26,4 +26,4 @@ mkZettelStore files = do
   pure $ Map.fromList $ zettels <&> zettelID &&& id
 
 lookupStore :: ZettelID -> ZettelStore -> Zettel
-lookupStore zid = fromMaybe (error $ "No such zettel: " <> show zid) . Map.lookup zid
+lookupStore zid = fromMaybe (error $ "No such zettel: " <> zettelIDText zid) . Map.lookup zid

--- a/test/Neuron/Zettelkasten/StoreSpec.hs
+++ b/test/Neuron/Zettelkasten/StoreSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.StoreSpec
+  ( spec,
+  )
+where
+
+import Control.Exception (evaluate)
+import qualified Data.Map.Strict as Map
+import Data.Time.Calendar
+import qualified Neuron.Zettelkasten.ID as Z
+import qualified Neuron.Zettelkasten.Store as Z
+import Relude
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Zettel Store" $ do
+    let day = fromGregorian 2020 3 19
+        emptyStore = Map.empty
+        dateZid = Z.ZettelDateID day 1
+        customZid = Z.ZettelCustomID "custom-id"
+    context "nonexistent zettel ID lookup" $ do
+      it "errors with text representation of date zettel ID" $ do
+        evaluate (Z.lookupStore dateZid emptyStore) `shouldThrow` errorCall "No such zettel: 2011401"
+      it "errors with custom zettel ID text" $ do
+        evaluate (Z.lookupStore customZid emptyStore) `shouldThrow` errorCall "No such zettel: custom-id"


### PR DESCRIPTION
I made a typo and transposed a couple of numbers in a zettel link. I was
getting an error message like `No such zettel: ZettelDateID 2020-03-19`,
but since there were a bunch of links in the doc, it took me a while to
figure out that this corresponded to the `[2011401]` link in my doc.
I've changed the error message for date IDs to include the text as it
would actually appear in the link in addition to the parsed day/index.

It would probably also be nice to get source line numbers on error
messages, but that sounds like a more ambitious effort.

I've never really written Haskell, so if I'm doing anything weird, it's
for no good reason, and please let me know.