### PR TITLE
Tag tree

### DIFF
--- a/neuron.cabal
+++ b/neuron.cabal
@@ -69,6 +69,7 @@ library
   exposed-modules:
     Neuron.CLI
     Neuron.CLI.New
+    Neuron.CLI.Query
     Neuron.CLI.Rib
     Neuron.CLI.Search
     Neuron.CLI.Types

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -62,7 +62,8 @@ common library-common
     megaparsec >= 8.0,
     some,
     dependent-sum,
-    dependent-sum-template
+    dependent-sum-template,
+    parser-combinators
 
 library
   import: library-common

--- a/src/Neuron/CLI.hs
+++ b/src/Neuron/CLI.hs
@@ -12,9 +12,9 @@ where
 
 import Development.Shake (Action)
 import Neuron.CLI.New (newZettelFile)
-import Neuron.CLI.Query
+import Neuron.CLI.Query (queryZettelkasten)
 import Neuron.CLI.Rib
-import Neuron.CLI.Search (runSearch)
+import Neuron.CLI.Search (interactiveSearch)
 import qualified Neuron.Version as Version
 import Options.Applicative
 import Relude
@@ -53,7 +53,7 @@ runWith act App {..} = do
         let opener = if os == "darwin" then "open" else "xdg-open"
         liftIO $ executeFile opener True [indexHtmlPath] Nothing
     Query q ->
-      runRibOnceQuietly notesDir $ do
-        runQuery notesDir q
+      runRibOnceQuietly notesDir $
+        queryZettelkasten notesDir q
     Search searchCmd ->
-      runSearch notesDir searchCmd
+      interactiveSearch notesDir searchCmd

--- a/src/Neuron/CLI/Query.hs
+++ b/src/Neuron/CLI/Query.hs
@@ -4,45 +4,39 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.CLI.Query
-  ( runQuery,
+  ( queryZettelkasten,
   )
 where
 
 import Data.Aeson
 import qualified Data.Aeson.Text as Aeson
-import qualified Data.Map.Strict as Map
 import Data.Some
 import Data.Tree (Tree (..))
 import Development.Shake (Action)
-import qualified Neuron.Util.Tree as Z
 import Neuron.Zettelkasten.ID (zettelIDSourceFileName)
-import qualified Neuron.Zettelkasten.Query as Z
-import qualified Neuron.Zettelkasten.Store as Z
-import Neuron.Zettelkasten.Tag (Tag (..), tagComponents)
+import Neuron.Zettelkasten.Query (Query (..), runQuery)
+import Neuron.Zettelkasten.Store (mkZettelStore)
+import Neuron.Zettelkasten.Tag (tagTree)
 import Neuron.Zettelkasten.Zettel (Zettel (..), zettelJson)
 import Relude
 import qualified Rib
 import System.FilePath
 
-runQuery :: FilePath -> Some Z.Query -> Action ()
-runQuery notesDir query = do
-  store <- Z.mkZettelStore =<< Rib.forEvery ["*.md"] pure
+queryZettelkasten :: FilePath -> Some Query -> Action ()
+queryZettelkasten notesDir query = do
+  store <- mkZettelStore =<< Rib.forEvery ["*.md"] pure
   case query of
-    Some (Z.Query_ZettelByID zid) -> do
-      let res = Z.lookupStore zid store
+    Some (Query_ZettelByID zid) -> do
+      let res = runQuery store (Query_ZettelByID zid)
       putLTextLn $ Aeson.encodeToLazyText $ zettelJsonWith res
-    Some (Z.Query_ZettelsByTag pats) -> do
-      let res = Z.runQuery store (Z.Query_ZettelsByTag pats)
+    Some (Query_ZettelsByTag pats) -> do
+      let res = runQuery store (Query_ZettelsByTag pats)
       putLTextLn $ Aeson.encodeToLazyText $ zettelJsonWith <$> res
-    Some (Z.Query_Tags pats) -> do
-      let tags = Z.runQuery store (Z.Query_Tags pats)
-          tagPaths = fmap tagComponents $ Map.keys tags
-          ann path =
-            let tag = fold $ intersperse "/" path
-             in fromMaybe 0 $ Map.lookup (Tag tag) tags
-          tree = Z.annotatePaths ann <$> Z.mkTreeFromPaths tagPaths
-      putLTextLn $ Aeson.encodeToLazyText $ toJSON $ fmap treeToJson tree
+    Some (Query_Tags pats) -> do
+      let tags = runQuery store (Query_Tags pats)
+      putLTextLn $ Aeson.encodeToLazyText $ toJSON $ fmap treeToJson (tagTree tags)
   where
+    -- TODO: Use newtype wrapper and write ToJSON
     treeToJson (Node (tag, count) children) =
       object
         [ "tag" .= tag,

--- a/src/Neuron/CLI/Query.hs
+++ b/src/Neuron/CLI/Query.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.CLI.Query
+  ( runQuery,
+  )
+where
+
+import Data.Aeson
+import qualified Data.Aeson.Text as Aeson
+import qualified Data.Map.Strict as Map
+import Data.Some
+import Data.Tree (Tree (..))
+import Development.Shake (Action)
+import qualified Neuron.Util.Tree as Z
+import Neuron.Zettelkasten.ID (zettelIDSourceFileName)
+import qualified Neuron.Zettelkasten.Query as Z
+import qualified Neuron.Zettelkasten.Store as Z
+import Neuron.Zettelkasten.Tag (Tag (..), tagComponents)
+import Neuron.Zettelkasten.Zettel (Zettel (..), zettelJson)
+import Relude
+import qualified Rib
+import System.FilePath
+
+runQuery :: FilePath -> Some Z.Query -> Action ()
+runQuery notesDir query = do
+  store <- Z.mkZettelStore =<< Rib.forEvery ["*.md"] pure
+  case query of
+    Some (Z.Query_ZettelByID zid) -> do
+      let res = Z.lookupStore zid store
+      putLTextLn $ Aeson.encodeToLazyText $ zettelJsonWith res
+    Some (Z.Query_ZettelsByTag pats) -> do
+      let res = Z.runQuery store (Z.Query_ZettelsByTag pats)
+      putLTextLn $ Aeson.encodeToLazyText $ zettelJsonWith <$> res
+    Some (Z.Query_Tags pats) -> do
+      let tags = Z.runQuery store (Z.Query_Tags pats)
+          tagPaths = fmap tagComponents $ Map.keys tags
+          ann path =
+            let tag = fold $ intersperse "/" path
+             in fromMaybe 0 $ Map.lookup (Tag tag) tags
+          tree = Z.annotatePaths ann <$> Z.mkTreeFromPaths tagPaths
+      putLTextLn $ Aeson.encodeToLazyText $ toJSON $ fmap treeToJson tree
+  where
+    treeToJson (Node (tag, count) children) =
+      object
+        [ "tag" .= tag,
+          "count" .= count,
+          "children" .= fmap treeToJson children
+        ]
+    zettelJsonWith z@Zettel {..} =
+      object $
+        [ "path" .= (notesDir </> zettelIDSourceFileName zettelID)
+        ]
+          <> zettelJson z

--- a/src/Neuron/CLI/Query.hs
+++ b/src/Neuron/CLI/Query.hs
@@ -39,7 +39,7 @@ queryZettelkasten notesDir query = do
     -- TODO: Use newtype wrapper and write ToJSON
     treeToJson (Node (tag, count) children) =
       object
-        [ "tag" .= tag,
+        [ "name" .= tag,
           "count" .= count,
           "children" .= fmap treeToJson children
         ]

--- a/src/Neuron/CLI/Search.hs
+++ b/src/Neuron/CLI/Search.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.CLI.Search
-  ( runSearch,
+  ( interactiveSearch,
   )
 where
 
@@ -29,8 +29,8 @@ searchScriptArgs SearchCommand {..} =
         bool "echo" "$EDITOR" searchEdit
    in searchByArgs <> [editArg]
 
-runSearch :: FilePath -> SearchCommand -> IO ()
-runSearch notesDir searchCmd =
+interactiveSearch :: FilePath -> SearchCommand -> IO ()
+interactiveSearch notesDir searchCmd =
   execScript neuronSearchScript $ notesDir : searchScriptArgs searchCmd
   where
     execScript scriptPath args =

--- a/src/Neuron/CLI/Types.hs
+++ b/src/Neuron/CLI/Types.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/src/Neuron/CLI/Types.hs
+++ b/src/Neuron/CLI/Types.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/src/Neuron/Util/Tree.hs
+++ b/src/Neuron/Util/Tree.hs
@@ -3,7 +3,7 @@
 module Neuron.Util.Tree
   ( mkTreeFromPaths,
     annotatePathsWith,
-    foldTreeOnWith,
+    foldSingleParentsWith,
   )
 where
 
@@ -27,15 +27,15 @@ annotatePathsWith f = go []
       let path = rel :| ancestors
        in Node (rel, f $ NE.reverse path) $ fmap (go $ toList path) children
 
--- | Fold one-child nodes that satisfy a predicate
+-- | Fold nodes with one child using the given function
 --
--- The node which satisfies the predicate will be folded with its only child
--- using the given function.
-foldTreeOnWith :: (a -> Bool) -> (a -> a -> a) -> Tree a -> Tree a
-foldTreeOnWith p f = go
+-- The function is called with the parent and the only child. If a Just value is
+-- returned, folding happens with that value, otherwise there is no effect.
+foldSingleParentsWith :: (a -> a -> Maybe a) -> Tree a -> Tree a
+foldSingleParentsWith f = go
   where
     go (Node parent children) =
       case fmap go children of
         [Node child grandChildren]
-          | p parent -> Node (f parent child) grandChildren
+          | Just new <- f parent child -> Node new grandChildren
         xs -> Node parent xs

--- a/src/Neuron/Util/Tree.hs
+++ b/src/Neuron/Util/Tree.hs
@@ -26,12 +26,14 @@ annotatePathsWith f = go []
       let path = rel : root
        in Node (rel, f $ reverse path) $ fmap (go path) children
 
--- TODO: What does this function do?
+-- | Fold one-child nodes that satisfy a predicate
+--
+-- The given function is called to fold a parent and its (only) child.
 foldTreeOnWith :: (a -> Bool) -> (a -> a -> a) -> Tree a -> Tree a
-foldTreeOnWith foldPredicate concatPaths = go
+foldTreeOnWith p f = go
   where
     go (Node parent children) =
       case fmap go children of
-        [Node dir grandChildren]
-          | foldPredicate parent -> Node (concatPaths parent dir) grandChildren
+        [Node child grandChildren]
+          | p parent -> Node (f parent child) grandChildren
         xs -> Node parent xs

--- a/src/Neuron/Util/Tree.hs
+++ b/src/Neuron/Util/Tree.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Util.Tree
+  ( mkTreeFromPaths,
+    annotatePaths,
+    foldTreeOnWith,
+  )
+where
+
+import qualified Data.Map as Map
+import Data.Tree
+import Relude
+import Relude.Extra.Group
+
+mkTreeFromPaths :: Ord a => [[a]] -> Forest a
+mkTreeFromPaths paths = uncurry mkNode <$> Map.assocs groups
+  where
+    groups = fmap tail <$> groupBy head (catMaybes $ fmap nonEmpty paths)
+    mkNode label children =
+      Node label $ mkTreeFromPaths $ toList children
+
+annotatePaths :: ([a] -> ann) -> Tree a -> Tree (a, ann)
+annotatePaths f = go []
+  where
+    go root (Node rel children) =
+      let path = rel : root
+       in Node (rel, f $ reverse path) $ fmap (go path) children
+
+foldTreeOnWith :: (a -> Bool) -> (a -> a -> a) -> Tree a -> Tree a
+foldTreeOnWith foldPredicate concatPaths = go
+  where
+    go (Node parent children) =
+      case fmap go children of
+        [Node dir grandChildren]
+          | foldPredicate parent -> Node (concatPaths parent dir) grandChildren
+        xs -> Node parent xs

--- a/src/Neuron/Util/Tree.hs
+++ b/src/Neuron/Util/Tree.hs
@@ -2,7 +2,7 @@
 
 module Neuron.Util.Tree
   ( mkTreeFromPaths,
-    annotatePaths,
+    annotatePathsWith,
     foldTreeOnWith,
   )
 where
@@ -15,17 +15,18 @@ import Relude.Extra.Group
 mkTreeFromPaths :: Ord a => [[a]] -> Forest a
 mkTreeFromPaths paths = uncurry mkNode <$> Map.assocs groups
   where
-    groups = fmap tail <$> groupBy head (catMaybes $ fmap nonEmpty paths)
+    groups = fmap tail <$> groupBy head (mapMaybe nonEmpty paths)
     mkNode label children =
       Node label $ mkTreeFromPaths $ toList children
 
-annotatePaths :: ([a] -> ann) -> Tree a -> Tree (a, ann)
-annotatePaths f = go []
+annotatePathsWith :: ([a] -> ann) -> Tree a -> Tree (a, ann)
+annotatePathsWith f = go []
   where
     go root (Node rel children) =
       let path = rel : root
        in Node (rel, f $ reverse path) $ fmap (go path) children
 
+-- TODO: What does this function do?
 foldTreeOnWith :: (a -> Bool) -> (a -> a -> a) -> Tree a -> Tree a
 foldTreeOnWith foldPredicate concatPaths = go
   where

--- a/src/Neuron/Util/Tree.hs
+++ b/src/Neuron/Util/Tree.hs
@@ -7,6 +7,7 @@ module Neuron.Util.Tree
   )
 where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import Data.Tree
 import Relude
@@ -19,16 +20,17 @@ mkTreeFromPaths paths = uncurry mkNode <$> Map.assocs groups
     mkNode label children =
       Node label $ mkTreeFromPaths $ toList children
 
-annotatePathsWith :: ([a] -> ann) -> Tree a -> Tree (a, ann)
+annotatePathsWith :: (NonEmpty a -> ann) -> Tree a -> Tree (a, ann)
 annotatePathsWith f = go []
   where
-    go root (Node rel children) =
-      let path = rel : root
-       in Node (rel, f $ reverse path) $ fmap (go path) children
+    go ancestors (Node rel children) =
+      let path = rel :| ancestors
+       in Node (rel, f $ NE.reverse path) $ fmap (go $ toList path) children
 
 -- | Fold one-child nodes that satisfy a predicate
 --
--- The given function is called to fold a parent and its (only) child.
+-- The node which satisfies the predicate will be folded with its only child
+-- using the given function.
 foldTreeOnWith :: (a -> Bool) -> (a -> a -> a) -> Tree a -> Tree a
 foldTreeOnWith p f = go
   where

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -41,7 +41,7 @@ import Neuron.Zettelkasten.Link.View (neuronLinkExt, renderZettelLink)
 import Neuron.Zettelkasten.Markdown (neuronMMarkExts)
 import Neuron.Zettelkasten.Query
 import Neuron.Zettelkasten.Store
-import Neuron.Zettelkasten.Tag (Tag (..))
+import Neuron.Zettelkasten.Tag
 import Neuron.Zettelkasten.Zettel
 import Relude
 import qualified Rib
@@ -189,16 +189,16 @@ renderBrandFooter withVersion =
 
 renderTags :: Monad m => [Tag] -> HtmlT m ()
 renderTags tags = do
-  forM_ tags $ \tag -> do
+  forM_ tags $ \(unTag -> tag) -> do
     -- TODO: Ideally this should be at the top, not bottom. But putting it at
     -- the top pushes the zettel content down, introducing unnecessary white
     -- space below the title. So we put it at the bottom for now.
     span_ [class_ "ui black right ribbon label", title_ "Tag"] $ do
       a_
-        [ href_ $ routeUrlRelWithQuery Route_Search [queryKey|tag|] (unTag tag),
-          title_ ("See all zettels tagged '" <> unTag tag <> "'")
+        [ href_ $ routeUrlRelWithQuery Route_Search [queryKey|tag|] tag,
+          title_ ("See all zettels tagged '" <> tag <> "'")
         ]
-        $ toHtml (unTag tag)
+        $ toHtml tag
     p_ mempty
 
 -- | Font awesome element
@@ -287,6 +287,13 @@ style Config {..} = do
     codeStyle
     blockquoteStyle
     kbd ? mozillaKbdStyle
+  "div.tag-tree" ? do
+    "div.rel-tag" ? do
+      C.fontWeight C.bold
+    "div.rel-tag:hover" ? do
+      C.background C.oldlace
+    "span.zettel-count" ? do
+      C.float C.floatRight
   "div.connections" ? do
     "a" ? do
       C.important $ color white

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -290,6 +290,8 @@ style Config {..} = do
   "div.tag-tree" ? do
     "div.node" ? do
       C.fontWeight C.bold
+      "a.inactive" ? do
+        C.color "#555"
   "div.connections" ? do
     "a" ? do
       C.important $ color white

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -288,12 +288,8 @@ style Config {..} = do
     blockquoteStyle
     kbd ? mozillaKbdStyle
   "div.tag-tree" ? do
-    "div.rel-tag" ? do
+    "div.node" ? do
       C.fontWeight C.bold
-    "div.rel-tag:hover" ? do
-      C.background C.oldlace
-    "span.zettel-count" ? do
-      C.float C.floatRight
   "div.connections" ? do
     "a" ? do
       C.important $ color white

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -18,6 +18,7 @@ module Neuron.Zettelkasten.ID
     mkZettelID,
     zettelNextIdForToday,
     zettelIDSourceFileName,
+    customIDParser,
   )
 where
 

--- a/src/Neuron/Zettelkasten/Link.hs
+++ b/src/Neuron/Zettelkasten/Link.hs
@@ -14,7 +14,6 @@
 module Neuron.Zettelkasten.Link where
 
 import Control.Monad.Except
-import qualified Data.Map.Strict as Map
 import Data.Some
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link.Theme
@@ -32,7 +31,7 @@ type instance QueryConnection Zettel = Connection
 
 type instance QueryConnection [Zettel] = Connection
 
-type instance QueryConnection (Map.Map Tag Natural) = ()
+type instance QueryConnection (Map Tag Natural) = ()
 
 type family QueryViewTheme q
 
@@ -40,7 +39,7 @@ type instance QueryViewTheme Zettel = ZettelView
 
 type instance QueryViewTheme [Zettel] = ZettelsView
 
-type instance QueryViewTheme (Map.Map Tag Natural) = ()
+type instance QueryViewTheme (Map Tag Natural) = ()
 
 -- TODO: Refactor to be a GADT using Some, and derive GEq, etc. correctly
 data NeuronLink

--- a/src/Neuron/Zettelkasten/Link.hs
+++ b/src/Neuron/Zettelkasten/Link.hs
@@ -14,6 +14,7 @@
 module Neuron.Zettelkasten.Link where
 
 import Control.Monad.Except
+import qualified Data.Map.Strict as Map
 import Data.Some
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link.Theme
@@ -31,7 +32,7 @@ type instance QueryConnection Zettel = Connection
 
 type instance QueryConnection [Zettel] = Connection
 
-type instance QueryConnection [Tag] = ()
+type instance QueryConnection (Map.Map Tag Natural) = ()
 
 type family QueryViewTheme q
 
@@ -39,7 +40,7 @@ type instance QueryViewTheme Zettel = ZettelView
 
 type instance QueryViewTheme [Zettel] = ZettelsView
 
-type instance QueryViewTheme [Tag] = ()
+type instance QueryViewTheme (Map.Map Tag Natural) = ()
 
 -- TODO: Refactor to be a GADT using Some, and derive GEq, etc. correctly
 data NeuronLink

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -19,7 +19,6 @@ import qualified Data.Map.Strict as Map
 import Data.Some
 import Data.Tree
 import Lucid
-import Neuron.Util.Tree
 import Neuron.Web.Route (Route (..), routeUrlRelWithQuery)
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Link
@@ -27,7 +26,7 @@ import Neuron.Zettelkasten.Link.Theme
 import Neuron.Zettelkasten.Markdown (MarkdownLink (..))
 import Neuron.Zettelkasten.Query
 import Neuron.Zettelkasten.Store
-import Neuron.Zettelkasten.Tag (Tag (..), tagMatchAny, tagTree)
+import Neuron.Zettelkasten.Tag (Tag (..), foldTagTree, tagMatchAny, tagTree)
 import Neuron.Zettelkasten.Zettel
 import Relude
 import qualified Rib
@@ -73,11 +72,7 @@ renderNeuronLink store = \case
   NeuronLink (q@(Query_Tags _), (), ()) -> do
     -- Render a list of tags
     toHtml $ Some q
-    let tree = tagTree $ runQuery store q
-        concatRelTags (parent, _) (child, count) = (parent <> "/" <> child, count)
-        tagDoesNotExist (_, count) = count == 0
-        folded = fmap (foldTreeOnWith tagDoesNotExist concatRelTags) tree
-    renderTagTree folded
+    renderTagTree $ foldTagTree $ tagTree $ runQuery store q
   where
     sortZettelsReverseChronological =
       sortOn (Down . zettelIDDay . zettelID)

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -66,7 +66,9 @@ renderNeuronLink store = \case
         renderZettelLinks zettelsViewLinkTheme zettels
       True ->
         forM_ (Map.toList $ groupZettelsByTagsMatching pats zettels) $ \(tag, zettelGrp) -> do
-          span_ [class_ "ui basic pointing below grey label"] $ toHtml $ unTag tag
+          span_ [class_ "ui basic pointing below grey label"] $ do
+            i_ [class_ "tag icon"] mempty
+            toHtml $ unTag tag
           renderZettelLinks zettelsViewLinkTheme zettelGrp
   NeuronLink (q@(Query_Tags _), (), ()) -> do
     -- Render a list of tags

--- a/src/Neuron/Zettelkasten/Query.hs
+++ b/src/Neuron/Zettelkasten/Query.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -20,7 +21,6 @@ import Control.Monad.Except
 import Data.GADT.Compare.TH
 import Data.GADT.Show.TH
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import Data.Some
 import Lucid
 import Neuron.Zettelkasten.ID
@@ -39,7 +39,7 @@ import qualified Text.URI as URI
 data Query r where
   Query_ZettelByID :: ZettelID -> Query Zettel
   Query_ZettelsByTag :: [TagPattern] -> Query [Zettel]
-  Query_Tags :: [TagPattern] -> Query [Tag]
+  Query_Tags :: [TagPattern] -> Query (Map.Map Tag Natural)
 
 instance ToHtml (Some Query) where
   toHtmlRaw = toHtml
@@ -53,13 +53,17 @@ instance ToHtml (Some Query) where
         Some (Query_ZettelsByTag (fmap unTagPattern -> pats)) -> do
           let qs = intercalate ", " pats
               desc = toText $ "Zettels tagged '" <> qs <> "'"
-           in span_ [class_ "ui basic pointing below black label", title_ desc] $ toHtml qs
+           in span_ [class_ "ui basic pointing below black label", title_ desc] $ do
+                with (i_ mempty) [class_ "sticky note outline icon"]
+                toHtml qs
         Some (Query_Tags []) ->
           "All tags"
         Some (Query_Tags (fmap unTagPattern -> pats)) -> do
           let qs = intercalate ", " pats
-          "Tags matching: "
-          toHtml qs
+              desc = toText $ "Tags matching '" <> qs <> "'"
+           in span_ [class_ "ui basic pointing below grey label", title_ desc] $ do
+                with (i_ mempty) [class_ "tags icon"]
+                toHtml qs
 
 type QueryResults = [Zettel]
 
@@ -113,9 +117,14 @@ runQuery store = \case
   Query_Tags [] ->
     allTags
   Query_Tags pats ->
-    filter (tagMatchAny pats) allTags
+    let match tag _ = tagMatchAny pats tag
+     in Map.filterWithKey match allTags
   where
-    allTags = Set.toList $ Set.fromList $ foldMap zettelTags (Map.elems store)
+    allTags :: Map.Map Tag Natural
+    allTags =
+      Map.fromListWith (+)
+        $ concatMap (\Zettel {..} -> (,1) <$> zettelTags)
+        $ Map.elems store
 
 deriveGEq ''Query
 
@@ -125,10 +134,10 @@ deriving instance Show (Query Zettel)
 
 deriving instance Show (Query [Zettel])
 
-deriving instance Show (Query [Tag])
+deriving instance Show (Query (Map.Map Tag Natural))
 
 deriving instance Eq (Query Zettel)
 
 deriving instance Eq (Query [Zettel])
 
-deriving instance Eq (Query [Tag])
+deriving instance Eq (Query (Map.Map Tag Natural))

--- a/src/Neuron/Zettelkasten/Query.hs
+++ b/src/Neuron/Zettelkasten/Query.hs
@@ -39,7 +39,7 @@ import qualified Text.URI as URI
 data Query r where
   Query_ZettelByID :: ZettelID -> Query Zettel
   Query_ZettelsByTag :: [TagPattern] -> Query [Zettel]
-  Query_Tags :: [TagPattern] -> Query (Map.Map Tag Natural)
+  Query_Tags :: [TagPattern] -> Query (Map Tag Natural)
 
 instance ToHtml (Some Query) where
   toHtmlRaw = toHtml
@@ -59,6 +59,7 @@ instance ToHtml (Some Query) where
         Some (Query_Tags []) ->
           "All tags"
         Some (Query_Tags (fmap unTagPattern -> pats)) -> do
+          -- TODO: UI header is wrong; not a tag
           let qs = intercalate ", " pats
               desc = toText $ "Tags matching '" <> qs <> "'"
            in span_ [class_ "ui basic pointing below grey label", title_ desc] $ do
@@ -117,8 +118,7 @@ runQuery store = \case
   Query_Tags [] ->
     allTags
   Query_Tags pats ->
-    let match tag _ = tagMatchAny pats tag
-     in Map.filterWithKey match allTags
+    Map.filterWithKey (const . tagMatchAny pats) allTags
   where
     allTags :: Map.Map Tag Natural
     allTags =
@@ -134,10 +134,10 @@ deriving instance Show (Query Zettel)
 
 deriving instance Show (Query [Zettel])
 
-deriving instance Show (Query (Map.Map Tag Natural))
+deriving instance Show (Query (Map Tag Natural))
 
 deriving instance Eq (Query Zettel)
 
 deriving instance Eq (Query [Zettel])
 
-deriving instance Eq (Query (Map.Map Tag Natural))
+deriving instance Eq (Query (Map Tag Natural))

--- a/src/Neuron/Zettelkasten/Query.hs
+++ b/src/Neuron/Zettelkasten/Query.hs
@@ -54,17 +54,13 @@ instance ToHtml (Some Query) where
           let qs = intercalate ", " pats
               desc = toText $ "Zettels tagged '" <> qs <> "'"
            in span_ [class_ "ui basic pointing below black label", title_ desc] $ do
-                with (i_ mempty) [class_ "sticky note outline icon"]
+                i_ [class_ "tags icon"] mempty
                 toHtml qs
         Some (Query_Tags []) ->
           "All tags"
         Some (Query_Tags (fmap unTagPattern -> pats)) -> do
-          -- TODO: UI header is wrong; not a tag
           let qs = intercalate ", " pats
-              desc = toText $ "Tags matching '" <> qs <> "'"
-           in span_ [class_ "ui basic pointing below grey label", title_ desc] $ do
-                with (i_ mempty) [class_ "tags icon"]
-                toHtml qs
+          toHtml $ "Tags matching '" <> qs <> "'"
 
 type QueryResults = [Zettel]
 

--- a/src/Neuron/Zettelkasten/Tag.hs
+++ b/src/Neuron/Zettelkasten/Tag.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
+-- TODO: Move TagPattern to a different module, as well as tagTree to its own
+-- module.
 module Neuron.Zettelkasten.Tag
   ( Tag (..),
     TagPattern (unTagPattern),
@@ -9,35 +11,26 @@ module Neuron.Zettelkasten.Tag
     tagMatch,
     tagMatchAny,
     tagTree,
+    foldTagTree,
   )
 where
 
 import Data.Aeson
 import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 import Data.Tree (Forest)
-import Neuron.Util.Tree (annotatePathsWith, mkTreeFromPaths)
+import Neuron.Util.Tree (annotatePathsWith, foldTreeOnWith, mkTreeFromPaths)
 import Relude
 import System.FilePath (splitDirectories)
 import System.FilePattern
 
+-- | Tag metadata field in Zettel notes
 newtype Tag = Tag {unTag :: Text}
   deriving (Eq, Ord, Show, ToJSON, FromJSON)
 
-tagTree :: Num a => Map Tag a -> Forest (Text, a)
-tagTree tags =
-  annotatePathsWith countFor <$> mkTreeFromPaths tagPaths
-  where
-    tagPaths = tagComponents <$> Map.keys tags
-    countFor path =
-      let tag = fold $ intersperse "/" path
-       in fromMaybe 0 $ Map.lookup (Tag tag) tags
-    tagComponents :: Tag -> [Text]
-    tagComponents =
-      fmap toText
-        . splitDirectories
-        . toString
-        . unTag
-
+-- | Glob-based pattern matching of tags
+--
+-- Eg.: "foo/**" matches both "foo/bar/baz" and "foo/baz"
 newtype TagPattern = TagPattern {unTagPattern :: FilePattern}
   deriving (Eq, Show)
 
@@ -54,3 +47,30 @@ tagMatchAny pats tag =
   -- TODO: Use step from https://hackage.haskell.org/package/filepattern-0.1.2/docs/System-FilePattern.html#v:step
   -- for efficient matching.
   any (`tagMatch` tag) pats
+
+-- | Construct a tree from a list of tags
+tagTree :: Num a => Map Tag a -> Forest (Text, a)
+tagTree tags =
+  fmap (annotatePathsWith $ countFor tags)
+    $ mkTreeFromPaths
+    $ fmap breakTag
+    $ Map.keys tags
+  where
+    countFor tags' path =
+      fromMaybe 0 $ Map.lookup (unbreakTag path) tags'
+    -- TODO: The breaking/unbreaking mechanism needs to be made more safe
+    breakTag :: Tag -> [Text]
+    breakTag =
+      fmap toText
+        . splitDirectories
+        . toString
+        . unTag
+    unbreakTag :: [Text] -> Tag
+    unbreakTag = Tag . T.intercalate "/"
+
+foldTagTree :: (Num a, Eq a) => Forest (Text, a) -> Forest (Text, a)
+foldTagTree tree =
+  fmap (foldTreeOnWith tagDoesNotExist concatRelTags) tree
+  where
+    concatRelTags (parent, _) (child, count) = (parent <> "/" <> child, count)
+    tagDoesNotExist (_, count) = count == 0

--- a/src/Neuron/Zettelkasten/Tag.hs
+++ b/src/Neuron/Zettelkasten/Tag.hs
@@ -1,10 +1,13 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Zettelkasten.Tag
   ( Tag (..),
+    tagComponents,
     TagPattern (unTagPattern),
     mkTagPattern,
     tagMatch,
@@ -14,10 +17,18 @@ where
 
 import Data.Aeson
 import Relude
+import System.FilePath (splitDirectories)
 import System.FilePattern
 
 newtype Tag = Tag {unTag :: Text}
   deriving (Eq, Ord, Show, ToJSON, FromJSON)
+
+tagComponents :: Tag -> [Text]
+tagComponents =
+  fmap toText
+    . splitDirectories
+    . toString
+    . unTag
 
 newtype TagPattern = TagPattern {unTagPattern :: FilePattern}
   deriving (Eq, Show)

--- a/test/Neuron/Util/TreeSpec.hs
+++ b/test/Neuron/Util/TreeSpec.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Util.TreeSpec
+  ( spec,
+  )
+where
+
+import Data.Tree (Forest, Tree (..))
+import qualified Neuron.Util.Tree as Z
+import Relude
+import System.FilePath ((</>))
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Path tree" $ do
+    context "Tree building" $ do
+      forM_ treeCases $ \(name, paths, tree) -> do
+        it name $ do
+          Z.mkTreeFromPaths paths `shouldBe` tree
+    context "Tree folding" $ do
+      forM_ foldingCases $ \(name, tree, folded) -> do
+        it name $ do
+          let mergePaths (p, _) (p', b') = (p </> p', b')
+              res = fmap fst $ Z.foldTreeOnWith snd mergePaths tree
+          res `shouldBe` folded
+
+treeCases :: [(String, [[String]], Forest String)]
+treeCases =
+  [ ( "works on one level",
+      [["journal"], ["science"]],
+      [Node "journal" [], Node "science" []]
+    ),
+    ( "groups paths with common prefix",
+      [["math", "algebra"], ["math", "calculus"]],
+      [Node "math" [Node "algebra" [], Node "calculus" []]]
+    ),
+    ( "ignores tag when there is also tag/subtag",
+      [["math"], ["math", "algebra"]],
+      [Node "math" [Node "algebra" []]]
+    )
+  ]
+
+foldingCases :: [(String, Tree (String, Bool), Tree String)]
+foldingCases =
+  [ ( "folds tree on one level",
+      Node ("math", True) [Node ("note", False) []],
+      Node "math/note" []
+    ),
+    ( "folds across multiple levels",
+      Node ("math", True) [Node ("algebra", True) [Node ("note", False) []]],
+      Node "math/algebra/note" []
+    ),
+    ( "does not fold tree when the predicate is false",
+      Node ("math", False) [Node ("note", False) []],
+      Node "math" [Node "note" []]
+    )
+  ]

--- a/test/Neuron/Util/TreeSpec.hs
+++ b/test/Neuron/Util/TreeSpec.hs
@@ -21,8 +21,8 @@ spec = do
     context "Tree folding" $ do
       forM_ foldingCases $ \(name, tree, folded) -> do
         it name $ do
-          let mergePaths (p, _) (p', b') = (p </> p', b')
-              res = fst <$> foldTreeOnWith snd mergePaths tree
+          let mergePaths (p, n) (p', b') = bool Nothing (Just (p </> p', b')) n
+              res = fst <$> foldSingleParentsWith mergePaths tree
           res `shouldBe` folded
 
 treeCases :: [(String, [[String]], Forest String)]

--- a/test/Neuron/Util/TreeSpec.hs
+++ b/test/Neuron/Util/TreeSpec.hs
@@ -6,7 +6,7 @@ module Neuron.Util.TreeSpec
 where
 
 import Data.Tree (Forest, Tree (..))
-import qualified Neuron.Util.Tree as Z
+import Neuron.Util.Tree
 import Relude
 import System.FilePath ((</>))
 import Test.Hspec
@@ -17,12 +17,12 @@ spec = do
     context "Tree building" $ do
       forM_ treeCases $ \(name, paths, tree) -> do
         it name $ do
-          Z.mkTreeFromPaths paths `shouldBe` tree
+          mkTreeFromPaths paths `shouldBe` tree
     context "Tree folding" $ do
       forM_ foldingCases $ \(name, tree, folded) -> do
         it name $ do
           let mergePaths (p, _) (p', b') = (p </> p', b')
-              res = fmap fst $ Z.foldTreeOnWith snd mergePaths tree
+              res = fst <$> foldTreeOnWith snd mergePaths tree
           res `shouldBe` folded
 
 treeCases :: [(String, [[String]], Forest String)]

--- a/test/Neuron/Zettelkasten/TagSpec.hs
+++ b/test/Neuron/Zettelkasten/TagSpec.hs
@@ -15,14 +15,14 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "Tag matching" $ do
-    forM_ tagMatchCases $ \(name, Z.mkTagPattern . toText -> pat, fmap Z.Tag -> matching, fmap Z.Tag -> failing) -> do
+    forM_ tagMatchCases $ \(name, Z.mkTagPattern -> pat, fmap Z.Tag -> matching, fmap Z.Tag -> failing) -> do
       it name $ do
         forM_ matching $ \tag -> do
           pat `shouldMatch` tag
         forM_ failing $ \tag -> do
           pat `shouldNotMatch` tag
 
-tagMatchCases :: [(String, String, [Text], [Text])]
+tagMatchCases :: [(String, Text, [Text], [Text])]
 tagMatchCases =
   [ ( "simple tag",
       "journal",


### PR DESCRIPTION
Implements #110.

The query command was implemented like this:
```
neuron query zettel ID
neuron query zettels [TAG]
neuron query tags [TAG] [--tree | --list (default) ]
neuron query --uri URI
```

The `--tree` argument provides a JSON tree where each node contains some information that would be useful for a tag browsing feature in editors, as discussed in the PR.