### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Continuous Integration"
 on:
   pull_request:
   push:
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v8


### PR DESCRIPTION
Looks like over time Nix hit the disk space limits on the [Github Actions VM](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners) which seems to be persistent between runs. 

Renaming the CI configuration seems to trigger a new VM build.