### PR TITLE
Refactor error handling

### DIFF
--- a/neuron.cabal
+++ b/neuron.cabal
@@ -81,6 +81,7 @@ library
     Neuron.Web.Route
     Neuron.Web.Theme
     Neuron.Web.View
+    Neuron.Zettelkasten.Error
     Neuron.Zettelkasten.Graph
     Neuron.Zettelkasten.ID
     Neuron.Zettelkasten.Link

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -45,9 +45,9 @@ renderPage config r val@(s, _, _) = html_ [lang_ "en"] $ do
         googleFonts [headerFont, bodyFont, monoFont]
         when (Config.mathJaxSupport config) $
           with (script_ mempty) [id_ "MathJax-script", src_ "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js", async_ ""]
-  body_ $
-    div_ [class_ "ui text container", id_ "thesite"] $
-      renderRouteBody config r val
+  body_
+    $ div_ [class_ "ui text container", id_ "thesite"]
+    $ renderRouteBody config r val
 
 headerFont :: Text
 headerFont = "Oswald"

--- a/src/Neuron/CLI/Types.hs
+++ b/src/Neuron/CLI/Types.hs
@@ -118,6 +118,6 @@ commandParser defaultNotesDir = do
     uriReader =
       eitherReader $ \(toText -> s) -> case URI.mkURI s of
         Right uri ->
-          first toString $ Z.queryFromURI uri
+          first show $ Z.queryFromURI uri
         Left e ->
           Left $ displayException e

--- a/src/Neuron/Web/Generate.hs
+++ b/src/Neuron/Web/Generate.hs
@@ -30,13 +30,18 @@ generateSite ::
   [FilePath] ->
   Action (Z.ZettelStore, Z.ZettelGraph)
 generateSite config writeHtmlRoute' zettelsPat = do
-  when (olderThan $ Z.minVersion config) $ do
-    error $ "Require neuron mininum version " <> Z.minVersion config <> ", but your neuron version is " <> neuronVersion
+  when (olderThan $ Z.minVersion config)
+    $ fail
+    $ toString
+    $ "Require neuron mininum version " <> Z.minVersion config <> ", but your neuron version is " <> neuronVersion
   zettelStore <- Z.mkZettelStore =<< Rib.forEvery zettelsPat pure
   zettelGraph <- either (fail . toString) pure $ Z.mkZettelGraph zettelStore
   let writeHtmlRoute v r = writeHtmlRoute' r (zettelStore, zettelGraph, v)
   -- Generate HTML for every zettel
-  (writeHtmlRoute () . Z.Route_Zettel) `mapM_` Map.keys zettelStore
+  forM_ (Map.toList zettelStore) $ \(k, v) ->
+    -- TODO: Should `Zettel` not contain ZettelID?
+    -- See duplication in `renderZettel`
+    writeHtmlRoute v $ Z.Route_Zettel k
   -- Generate the z-index
   writeHtmlRoute () Z.Route_ZIndex
   -- Generate search page

--- a/src/Neuron/Web/Generate.hs
+++ b/src/Neuron/Web/Generate.hs
@@ -33,7 +33,7 @@ generateSite config writeHtmlRoute' zettelsPat = do
   when (olderThan $ Z.minVersion config) $ do
     error $ "Require neuron mininum version " <> Z.minVersion config <> ", but your neuron version is " <> neuronVersion
   zettelStore <- Z.mkZettelStore =<< Rib.forEvery zettelsPat pure
-  let zettelGraph = Z.mkZettelGraph zettelStore
+  zettelGraph <- either (fail . toString) pure $ Z.mkZettelGraph zettelStore
   let writeHtmlRoute v r = writeHtmlRoute' r (zettelStore, zettelGraph, v)
   -- Generate HTML for every zettel
   (writeHtmlRoute () . Z.Route_Zettel) `mapM_` Map.keys zettelStore

--- a/src/Neuron/Web/Route.hs
+++ b/src/Neuron/Web/Route.hs
@@ -28,7 +28,7 @@ data Route store graph a where
   Route_Redirect :: ZettelID -> Route ZettelStore ZettelGraph ZettelID
   Route_ZIndex :: Route ZettelStore ZettelGraph ()
   Route_Search :: Route ZettelStore ZettelGraph ()
-  Route_Zettel :: ZettelID -> Route ZettelStore ZettelGraph ()
+  Route_Zettel :: ZettelID -> Route ZettelStore ZettelGraph Zettel
 
 instance IsRoute (Route store graph) where
   routeFile = \case

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -82,7 +82,7 @@ renderRouteBody config r (s, g, x) = do
     Route_Search {} ->
       renderSearch s
     Route_Zettel zid ->
-      renderZettel config (s, g) zid
+      renderZettel config (s, g, x) zid
     Route_Redirect _ ->
       meta_ [httpEquiv_ "Refresh", content_ $ "0; url=" <> (Rib.routeUrlRel $ Route_Zettel x)]
 
@@ -139,10 +139,9 @@ renderSearch store = do
   script_ $ "let index = " <> toText (Aeson.encodeToLazyText index) <> ";"
   script_ searchScript
 
-renderZettel :: forall m. Monad m => Config -> (ZettelStore, ZettelGraph) -> ZettelID -> HtmlT m ()
-renderZettel config@Config {..} (store, graph) zid = do
-  let Zettel {..} = lookupStore zid store
-      neuronTheme = Theme.mkTheme theme
+renderZettel :: forall m. Monad m => Config -> (ZettelStore, ZettelGraph, Zettel) -> ZettelID -> HtmlT m ()
+renderZettel config@Config {..} (store, graph, Zettel {..}) zid = do
+  let neuronTheme = Theme.mkTheme theme
   div_ [class_ "zettel-view"] $ do
     div_ [class_ "ui raised segments"] $ do
       div_ [class_ "ui top attached segment"] $ do

--- a/src/Neuron/Zettelkasten/Error.hs
+++ b/src/Neuron/Zettelkasten/Error.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.Error
+  ( NeuronError (..),
+  )
+where
+
+import Neuron.Zettelkasten.ID (ZettelID, zettelIDSourceFileName, zettelIDText)
+import Neuron.Zettelkasten.Link (InvalidNeuronLink (..))
+import Neuron.Zettelkasten.Link.Theme (InvalidLinkTheme (..))
+import Neuron.Zettelkasten.Query (InvalidQuery (..))
+import Relude
+import qualified Text.Show
+import qualified Text.URI as URI
+
+data NeuronError
+  = -- A zettel file contains invalid link that neuron cannot parse
+    NeuronError_BadLink ZettelID InvalidNeuronLink
+  | -- A zettel file refers to another that does not exist
+    NeuronError_BrokenZettelRef ZettelID ZettelID
+  deriving (Eq)
+
+instance Show NeuronError where
+  show e =
+    let fromZid = case e of
+          NeuronError_BadLink zid _ -> zid
+          NeuronError_BrokenZettelRef zid _ -> zid
+        msg = case e of
+          NeuronError_BadLink _ (InvalidNeuronLink uri le) ->
+            "it contains a query URI (" <> toString (URI.render uri) <> ") " <> case le of
+              Left (InvalidQuery_InvalidID s) ->
+                "with invalid ID: " <> show s
+              Left InvalidQuery_UnsupportedHost ->
+                "with unsupported host"
+              Left InvalidQuery_Unsupported ->
+                "that is not supported"
+              Right (InvalidLinkTheme theme) ->
+                "with invalid link theme (" <> toString theme <> ")"
+          NeuronError_BrokenZettelRef _fromZid toZid ->
+            "it references a zettel <" <> toString (zettelIDText toZid) <> "> that does not exist"
+     in "\n  The zettel file '" <> zettelIDSourceFileName fromZid <> "' is malformed\n    " <> msg <> "\n"

--- a/src/Neuron/Zettelkasten/Error.hs
+++ b/src/Neuron/Zettelkasten/Error.hs
@@ -30,7 +30,7 @@ instance Show NeuronError where
           NeuronError_BrokenZettelRef zid _ -> zid
         msg = case e of
           NeuronError_BadLink _ (InvalidNeuronLink uri le) ->
-            "it contains a query URI (" <> toString (URI.render uri) <> ") " <> case le of
+            "it contains a query URI (" <> URI.render uri <> ") " <> case le of
               Left (InvalidQuery_InvalidID s) ->
                 "with invalid ID: " <> show s
               Left InvalidQuery_UnsupportedHost ->
@@ -38,7 +38,11 @@ instance Show NeuronError where
               Left InvalidQuery_Unsupported ->
                 "that is not supported"
               Right (InvalidLinkTheme theme) ->
-                "with invalid link theme (" <> toString theme <> ")"
+                "with invalid link theme (" <> theme <> ")"
           NeuronError_BrokenZettelRef _fromZid toZid ->
-            "it references a zettel <" <> toString (zettelIDText toZid) <> "> that does not exist"
-     in "\n  The zettel file '" <> zettelIDSourceFileName fromZid <> "' is malformed\n    " <> msg <> "\n"
+            "it references a zettel <" <> zettelIDText toZid <> "> that does not exist"
+     in toString $ unlines
+          [ "",
+            "  Zettel file \"" <> toText (zettelIDSourceFileName fromZid) <> "\" is malformed:",
+            "    " <> msg
+          ]

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -47,12 +47,12 @@ neuronLinkExt store =
             Right Nothing ->
               f inline
             Left e ->
-              error e
+              error $ show e
     inline ->
       f inline
 
 -- | Render the custom view for the given neuron link
-renderNeuronLink :: forall m. Monad m => ZettelStore -> NeuronLink -> HtmlT m ()
+renderNeuronLink :: forall m. (Monad m, HasCallStack) => ZettelStore -> NeuronLink -> HtmlT m ()
 renderNeuronLink store = \case
   NeuronLink (Query_ZettelByID zid, _conn, linkTheme) ->
     -- Render a single link

--- a/src/Neuron/Zettelkasten/Link/View.hs
+++ b/src/Neuron/Zettelkasten/Link/View.hs
@@ -47,6 +47,9 @@ neuronLinkExt store =
             Right Nothing ->
               f inline
             Left e ->
+              -- TODO: Build the links during graph construction, and pass it to
+              -- the extension from rendering stage. This way we don't have to
+              -- re-parse the URIs and needlessly handle the errors.
               error $ show e
     inline ->
       f inline

--- a/src/Neuron/Zettelkasten/Store.hs
+++ b/src/Neuron/Zettelkasten/Store.hs
@@ -25,5 +25,5 @@ mkZettelStore files = do
   zettels <- mkZettelFromPath `mapM` files
   pure $ Map.fromList $ zettels <&> zettelID &&& id
 
-lookupStore :: ZettelID -> ZettelStore -> Zettel
+lookupStore :: HasCallStack => ZettelID -> ZettelStore -> Zettel
 lookupStore zid = fromMaybe (error $ "No such zettel: " <> zettelIDText zid) . Map.lookup zid

--- a/test/Neuron/ConfigSpec.hs
+++ b/test/Neuron/ConfigSpec.hs
@@ -9,8 +9,8 @@ module Neuron.ConfigSpec
   )
 where
 
-import Neuron.Parser
 import qualified Neuron.Config as Z
+import Neuron.Parser
 import qualified Neuron.Zettelkasten.ID as Z
 import Relude
 import Test.Hspec

--- a/test/Neuron/Zettelkasten/Link/ThemeSpec.hs
+++ b/test/Neuron/Zettelkasten/Link/ThemeSpec.hs
@@ -11,7 +11,7 @@ where
 import Neuron.Zettelkasten.Link.Theme
 import Relude
 import Test.Hspec
-import Text.URI (URI, mkURI)
+import Util
 
 spec :: Spec
 spec =
@@ -28,7 +28,3 @@ spec =
         `shouldBe` Right (ZettelsView LinkTheme_Default True)
       parseURIWith zettelsViewFromURI "zquery://search?tag=foo"
         `shouldBe` Right (ZettelsView LinkTheme_Default False)
-  where
-    parseURIWith :: (URI -> Either Text a) -> Text -> Either Text a
-    parseURIWith f =
-      either (Left . toText . displayException) f . mkURI

--- a/test/Neuron/Zettelkasten/QuerySpec.hs
+++ b/test/Neuron/Zettelkasten/QuerySpec.hs
@@ -11,7 +11,7 @@ import Neuron.Zettelkasten.Query
 import Neuron.Zettelkasten.Tag
 import Relude
 import Test.Hspec
-import Text.URI (mkURI)
+import Util
 
 spec :: Spec
 spec =
@@ -29,6 +29,5 @@ spec =
       parseQueryString "zquery://search?tag=foo&tag=bar"
         `shouldBe` Right (zettelsByTag ["foo", "bar"])
   where
-    parseQueryString :: Text -> Either Text (Some Query)
     parseQueryString =
-      either (Left . toText . displayException) queryFromURI . mkURI
+      parseURIWith queryFromURI

--- a/test/Util.hs
+++ b/test/Util.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Util where
+
+import Relude
+import Text.URI (URI, mkURI)
+
+parseURIWith :: (URI -> Either e a) -> Text -> Either (Either Text e) a
+parseURIWith f s =
+  case mkURI s of
+    Left uriError ->
+      Left $ Left $ toText $ displayException uriError
+    Right uri ->
+      first Right $ f uri


### PR DESCRIPTION
Resolves #120 and ameliorates #104

Also improves error messages, which now look like:

```
user error (
  The zettel file '2008316.md' is malformed
    it contains a query URI (zquery://search/?linkTheme=foo) with invalid link theme (foo)
)
```
```
user error (
  The zettel file '2008316.md' is malformed
    it contains a query URI (zquery://foo/) with unsupported host
)
```

```
user error (
  The zettel file '2008316.md' is malformed
    it references a zettel <1234567> that does not exist
)
```