### PR TITLE
Fix small issues in neuron-search

### DIFF
--- a/src-bash/neuron-search/default.nix
+++ b/src-bash/neuron-search/default.nix
@@ -14,7 +14,6 @@ pkgs.writeShellScriptBin "neuron-search"
     ${pkgs.ripgrep}/bin/rg --no-heading --no-line-number --with-filename --sort path "''${FILTERBY}" *.md \
       | ${pkgs.fzf}/bin/fzf --tac --no-sort -d ':' -n ''${SEARCHFROMFIELD}.. \
         --preview '${pkgs.bat}/bin/bat --style=plain --color=always {1}' \
-        --bind 'ctrl-j:execute(xdg-open http://localhost:8080/$(echo {1} | ${pkgs.gnused}/bin/sed "s/\.md/.html/g"))+abort' \
       | ${pkgs.gawk}/bin/awk -F: "{printf \"''${NOTESDIR}/%s\", \$1}" \
       | ${pkgs.findutils}/bin/xargs -r ''${OPENCMD}
   ''

--- a/src-bash/neuron-search/default.nix
+++ b/src-bash/neuron-search/default.nix
@@ -11,7 +11,7 @@ pkgs.writeShellScriptBin "neuron-search"
     SEARCHFROMFIELD=''${3}
     OPENCMD=`${pkgs.envsubst}/bin/envsubst -no-unset -no-empty <<< ''${4}`
     cd ''${NOTESDIR}
-    ${pkgs.ripgrep}/bin/rg --no-heading --no-line-number --sort path "''${FILTERBY}" *.md \
+    ${pkgs.ripgrep}/bin/rg --no-heading --no-line-number --with-filename --sort path "''${FILTERBY}" *.md \
       | ${pkgs.fzf}/bin/fzf --tac --no-sort -d ':' -n ''${SEARCHFROMFIELD}.. \
         --preview '${pkgs.bat}/bin/bat --style=plain --color=always {1}' \
         --bind 'ctrl-j:execute(xdg-open http://localhost:8080/$(echo {1} | ${pkgs.gnused}/bin/sed "s/\.md/.html/g"))+abort' \

--- a/src-bash/neuron-search/default.nix
+++ b/src-bash/neuron-search/default.nix
@@ -14,7 +14,7 @@ pkgs.writeShellScriptBin "neuron-search"
     ${pkgs.ripgrep}/bin/rg --no-heading --no-line-number --sort path "''${FILTERBY}" *.md \
       | ${pkgs.fzf}/bin/fzf --tac --no-sort -d ':' -n ''${SEARCHFROMFIELD}.. \
         --preview '${pkgs.bat}/bin/bat --style=plain --color=always {1}' \
-        --bind 'ctrl-j:execute(xdg-open https://localhost:8080/(echo {1} | ${pkgs.gnused}/bin/sed "s/\.md/.html/g"))+abort' \
+        --bind 'ctrl-j:execute(xdg-open http://localhost:8080/$(echo {1} | ${pkgs.gnused}/bin/sed "s/\.md/.html/g"))+abort' \
       | ${pkgs.gawk}/bin/awk -F: "{printf \"''${NOTESDIR}/%s\", \$1}" \
       | ${pkgs.findutils}/bin/xargs -r ''${OPENCMD}
   ''


### PR DESCRIPTION
`neuron rib -wS` spawns a http sever, but this command tried to open a https server. Additionally, the echo command was missing the `$` required to work. Now pressing ctrl-j in `neuron search` works as expected.

While browsing the issues, I also stumbled upon #56 and fixed that as well.

There remains the issue that if there are no markdown files in `NOTESDIR`, the script will exit with an error along the lines of:

```sh
*.md: IO error for operation on *.md: No such file or directory (os error 2)
```

which might not be desirable, but it's certainly a highly unusual circumstance given the nature of `neuron search`. 

Closes #56 