### PR TITLE
Add JSON-LD breadcrumbs to published site

### DIFF
--- a/guide/2011701.md
+++ b/guide/2011701.md
@@ -10,7 +10,7 @@ You may configure the parameters of your web interface by adding an optional con
 |---|---|
 |**`siteTitle`**|Your Neuron site's title|
 |**`author`**|Author name|
-|**`siteBaseUrl`**|The base URL of your published Neuron site|
+|**`siteBaseUrl`**|The base URL of your published Neuron site. Setting the base URL will enable [breadcrumbs](https://developers.google.com/search/docs/data-types/breadcrumb) in your site's structured data|
 |**`theme`**|Color scheme to use for your site. Value must be [one of the color names](https://semantic-ui.com/usage/theming.html#sitewide-defaults) supported by SemanticUI.|
 |**`aliases`**|Setup custom redirects in the statically generated site.|
 |**`editUrl`**|The URL (without the zettel filename) to edit zettels.|

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -72,6 +72,7 @@ library
     Data.Graph.Labelled
     Data.TagTree
     Data.PathTree
+    Data.Structured.Breadcrumb
     Neuron.CLI
     Neuron.CLI.New
     Neuron.CLI.Query

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -32,9 +32,9 @@ generateMainSite = do
   void $ generateSite config writeHtmlRoute ["*.md"]
 
 renderPage :: Config -> Route g a -> (g, a) -> Html ()
-renderPage config r val@(_, x) = html_ [lang_ "en"] $ do
+renderPage config r val = html_ [lang_ "en"] $ do
   head_ $ do
-    renderRouteHead config r x
+    renderRouteHead config r val
     case r of
       Route_Redirect _ ->
         mempty

--- a/src/Data/Structured/Breadcrumb.hs
+++ b/src/Data/Structured/Breadcrumb.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | JSON for Google's structured data breadcrumbs
+--
+-- https://developers.google.com/search/docs/data-types/breadcrumb
+module Data.Structured.Breadcrumb where
+
+import Data.Aeson
+import Data.Tree
+import Lucid
+import Relude
+import Text.URI (URI)
+import qualified Text.URI as URI
+
+data Item = Item
+  { name :: Text,
+    url :: Maybe URI
+  }
+  deriving (Eq, Show, Generic)
+
+newtype Breadcrumb = Breadcrumb {unBreadcrumb :: NonEmpty Item}
+  deriving (Eq, Show, Generic)
+
+instance ToHtml [Breadcrumb] where
+  toHtmlRaw = toHtml
+  toHtml bs =
+    script_ [type_ "application/ld+json"] $
+      encode bs
+
+instance ToJSON Breadcrumb where
+  toJSON (Breadcrumb (toList -> crumbs)) =
+    toJSON $
+      object
+        [ "@context" .= toJSON context,
+          "@type" .= ("BreadcrumbList" :: Text),
+          "itemListElement" .= toJSON (uncurry itemJson <$> zip [1 :: Int ..] crumbs)
+        ]
+    where
+      context = "https://schema.org" :: Text
+      itemJson pos Item {..} =
+        object
+          [ "@type" .= toJSON ("ListItem" :: Text),
+            "position" .= toJSON pos,
+            "name" .= toJSON name,
+            "item" .= toJSON (fmap URI.render url)
+          ]
+
+fromForest :: Forest Item -> [Breadcrumb]
+fromForest =
+  fmap Breadcrumb . mapMaybe (nonEmpty . reverse) . concatMap (foldTree f)
+  where
+    f :: Item -> [[[Item]]] -> [[Item]]
+    f parent = \case
+      [] -> [[parent]]
+      childPaths ->
+        fmap (parent :) `concatMap` childPaths
+{-
+    [{
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Books",
+        "item": "https://example.com/books"
+      },{
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Science Fiction",
+        "item": "https://example.com/books/sciencefiction"
+      },{
+        "@type": "ListItem",
+        "position": 3,
+        "name": "Award Winners"
+      }]
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Literature",
+        "item": "https://example.com/literature"
+      },{
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Award Winners"
+      }]
+    }]
+-}

--- a/src/Neuron/Config.hs
+++ b/src/Neuron/Config.hs
@@ -16,6 +16,7 @@ module Neuron.Config
   ( Config (..),
     getConfig,
     Alias (..),
+    BaseUrlError (..),
     getAliases,
     aliasParser,
     getMarkdownExtensions,
@@ -51,6 +52,12 @@ makeHaskellTypes
 deriving instance Generic Config
 
 deriving instance FromDhall Config
+
+data BaseUrlError
+  = BaseUrlNotAbsolute
+  deriving (Eq, Show)
+
+instance Exception BaseUrlError
 
 data Alias = Alias
   { aliasZettel :: Z.ZettelID,

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -55,11 +55,11 @@ searchScript = $(embedStringFile "./src-js/search.js")
 helloScript :: Text
 helloScript = $(embedStringFile "./src-purescript/hello/index.js")
 
-renderRouteHead :: Monad m => Config -> Route graph a -> a -> HtmlT m ()
+renderRouteHead :: Monad m => Config -> Route graph a -> (graph, a) -> HtmlT m ()
 renderRouteHead config r val = do
   meta_ [httpEquiv_ "Content-Type", content_ "text/html; charset=utf-8"]
   meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
-  title_ $ toHtml $ routeTitle config val r
+  title_ $ toHtml $ routeTitle config (snd val) r
   link_ [rel_ "shortcut icon", href_ "https://raw.githubusercontent.com/srid/neuron/master/assets/logo.ico"]
   case r of
     Route_Redirect _ ->
@@ -69,7 +69,8 @@ renderRouteHead config r val = do
       with (script_ mempty) [src_ "https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"]
       with (script_ mempty) [src_ "https://cdn.jsdelivr.net/npm/js-search@2.0.0/dist/umd/js-search.min.js"]
     _ -> do
-      toHtml $ routeOpenGraph config val r
+      toHtml $ routeOpenGraph config (snd val) r
+      toHtml $ routeStructuredData config val r
       style_ [type_ "text/css"] $ styleToCss tango
 
 renderRouteBody :: Monad m => Config -> Route graph a -> (graph, a) -> HtmlT m ()


### PR DESCRIPTION
Generated based on the zettelkasten graph. And matches the "Navigate Up" tree.

Enabed only if `siteBaseUrl` is set in neuron.dhall

For #27 