### PR TITLE
True backlinks support

### DIFF
--- a/guide/2011503.md
+++ b/guide/2011503.md
@@ -2,7 +2,7 @@
 title: Graph view
 ---
 
-A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_graph), which may be visualized as a forest (a tree with multiple roots). Neuron renders this forest, which may be considered to be an automatic "category tree" that evolves in your Zettelkasten over time. 
+A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_graph), and <2017401> is a subset of this graph established using special links.
 
 ## z-index 
 
@@ -10,5 +10,5 @@ The z-index page (at `/z-index.html`; also linked in the footer) displays your Z
 
 ## Connections
 
-Each zettel has a "connection" pane at the bottom. It shows both the outgoing and the incoming links to/from other zettels.
+Each zettel has a "connection" pane at the bottom. It shows both the children and the parent connections to other zettels (as defined by <2017401> connections), as well the backlinks not part of the tree. 
 

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -14,9 +14,9 @@ You may also annotate the link (ignored by neuron):
 - [2008403](z://foo-bar).
 ```
 
-The `z:` protocol instructs neuron to automatically create a link between the associated zettels, which ultimately affects your zettel graph. Neuron also renders the link along with the ID and title of the linked zettel.
+The `z:` protocol instructs neuron to automatically create a link between the associated zettels, which ultimately affects the category tree of your zettel graph. Neuron also renders the link along with the ID and title of the linked zettel.
 
-If your link is merely a reference to another zettel, and you do not wish it to be also a graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2011503](zcf://graph-view).
+If your link is merely a reference to another zettel, and you do not wish it to be part of the category tree, but only the graph connection, use `zcf:` instead. Neuron will link the zettels, but the link would be ignored when building the [2017401](zcf:).
 
 ## Other link types
 

--- a/guide/2011506.md
+++ b/guide/2011506.md
@@ -21,8 +21,8 @@ Zettelkasten:
 [.](zcfquery://search?tag=walkthrough)
 
 It was created by `[.](zcfquery://search?tag=walkthrough)`. Note that here we
-use `zcfquery` to not affect the graph; whereas `zquery` will form the
-appropriate new connections to the listed notes.
+use `zcfquery` to not affect the category tree of the graph; whereas `zquery` will form the
+appropriate new category connections to the listed notes.
 
 ## Hierarchical tags
 

--- a/guide/2017401.md
+++ b/guide/2017401.md
@@ -1,0 +1,9 @@
+---
+title: Category Tree
+---
+
+Neuron allows you to organically build a category tree out of your Zettelkasten graph. This is achieved by using `z:` links instead of `zcf:` (see [2011504](zcf://linking)). The category tree is displayed in the z-index, as well as the connections panel of each zettel.
+
+## See also
+
+* The [z-index](/z-index.html) of this site show its category tree.

--- a/src/Data/Graph/Labelled.hs
+++ b/src/Data/Graph/Labelled.hs
@@ -13,12 +13,13 @@ module Data.Graph.Labelled
     getVertices,
 
     -- * Algorithms
-    backlinks,
+    preSet,
     topSort,
     clusters,
     dfsForestFrom,
     dfsForestBackwards,
     obviateRootUnlessForest,
+    induceOnEdge,
   )
 where
 

--- a/src/Data/Graph/Labelled/Algorithm.hs
+++ b/src/Data/Graph/Labelled/Algorithm.hs
@@ -29,8 +29,8 @@ getVertices (LabelledGraph _ lm) =
   Map.elems lm
 
 -- | Return the backlinks to the given vertex
-backlinks :: (Vertex v, Ord (VertexID v)) => v -> LabelledGraph v e -> [v]
-backlinks (vertexID -> zid) g =
+preSet :: (Vertex v, Ord (VertexID v)) => v -> LabelledGraph v e -> [v]
+preSet (vertexID -> zid) g =
   fmap (getVertex g) $ toList . LAM.preSet zid $ graph g
 
 topSort :: (Vertex v, Ord (VertexID v)) => LabelledGraph v e -> Either (NonEmpty v) [v]
@@ -59,6 +59,15 @@ dfsForestBackwards fromV (LabelledGraph g' v') =
 --------------------------
 --- More general utilities
 --------------------------
+
+-- | Like `induce` but operates on edges instead of vertices
+induceOnEdge :: Ord (VertexID v) => (e -> Bool) -> LabelledGraph v e -> LabelledGraph v e
+induceOnEdge f (LabelledGraph g v) =
+  LabelledGraph g' v
+  where
+    g' =
+      let es = mapMaybe (\(e, a, b) -> if f e then Nothing else Just (a, b)) $ LAM.edgeList g
+       in foldl' (\h (a, b) -> LAM.removeEdge a b h) g es
 
 -- | Get the clusters in a graph, as a list of the mother vertices in each
 -- cluster.

--- a/src/Data/Graph/Labelled/Type.hs
+++ b/src/Data/Graph/Labelled/Type.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Data.Graph.Labelled.Type where
@@ -25,3 +27,5 @@ data LabelledGraph v e = LabelledGraph
   { graph :: LAM.AdjacencyMap e (VertexID v),
     vertices :: Map (VertexID v) v
   }
+
+deriving instance (Ord e, Show e, Show v, Ord (VertexID v), Show (VertexID v)) => Show (LabelledGraph v e)

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -27,7 +27,6 @@ import Data.Aeson ((.=), object)
 import qualified Data.Aeson.Text as Aeson
 import Data.FileEmbed (embedStringFile)
 import Data.Foldable (maximum)
-import qualified Data.Graph.Labelled as G
 import qualified Data.Set as Set
 import Data.TagTree (Tag (..))
 import Data.Tree (Tree (..))
@@ -36,6 +35,8 @@ import Neuron.Config
 import Neuron.Version (neuronVersionFull)
 import Neuron.Web.Route
 import qualified Neuron.Web.Theme as Theme
+import Neuron.Zettelkasten.Connection
+import qualified Neuron.Zettelkasten.Graph as G
 import Neuron.Zettelkasten.Graph (ZettelGraph)
 import Neuron.Zettelkasten.ID (ZettelID (..), zettelIDSourceFileName, zettelIDText)
 import Neuron.Zettelkasten.Query.Theme (LinkTheme (..))
@@ -97,21 +98,18 @@ renderIndex Config {..} graph = do
         forM_ cyc $ \zettel ->
           li_ $ renderZettelLink LinkTheme_Default zettel
       _ -> mempty
-    let clusters = sortMothers $ G.clusters graph
+    let clusters = G.categoryClusters graph
     p_ $ do
       "There " <> countNounBe "cluster" "clusters" (length clusters) <> " in the Zettelkasten graph. "
       "Each cluster is rendered as a forest, with their roots (mother zettels) highlighted."
-    forM_ clusters $ \zids ->
+    forM_ clusters $ \forest ->
       div_ [class_ $ "ui stacked " <> Theme.semanticColor neuronTheme <> " segment"] $ do
-        let forest = G.dfsForestFrom zids graph
         -- Forest of zettels, beginning with mother vertices.
         ul_ $ renderForest True Nothing LinkTheme_Default graph forest
     renderBrandFooter True
   -- See ./src-purescript/hello/README.md
   script_ helloScript
   where
-    -- Sort clusters with newer mother zettels appearing first.
-    sortMothers ms = sortOn (Down . maximum) $ fmap (sortOn Down . toList) ms
     countNounBe noun nounPlural = \case
       1 -> "is 1 " <> noun
       n -> "are " <> show n <> " " <> nounPlural
@@ -123,7 +121,7 @@ renderSearch graph = do
     input_ [type_ "text", id_ "search-input"]
     fa "search icon fas fa-search"
   div_ [class_ "ui hidden divider"] mempty
-  let allZettels = G.getVertices graph
+  let allZettels = G.getZettels graph
       allTags = Set.fromList $ concatMap zettelTags allZettels
       index = object ["zettels" .= fmap (object . zettelJson) allZettels, "tags" .= allTags]
   div_ [class_ "ui fluid multiple search selection dropdown", id_ "search-tags"] $ do
@@ -152,14 +150,19 @@ renderZettel config@Config {..} (graph, (z@Zettel {..}, ext)) zid = do
     div_ [class_ $ "ui inverted " <> Theme.semanticColor neuronTheme <> " top attached connections segment"] $ do
       div_ [class_ "ui two column grid"] $ do
         div_ [class_ "column"] $ do
-          div_ [class_ "ui header"] "Connections"
-          let forest = G.obviateRootUnlessForest z $ G.dfsForestFrom [z] graph
-          ul_ $ renderForest True (Just 2) LinkTheme_Simple graph forest
+          div_ [class_ "ui header"] "Children"
+          ul_ $ renderForest True (Just 2) LinkTheme_Simple graph $
+            G.frontlinkForest Folgezettel z graph
         div_ [class_ "column"] $ do
-          div_ [class_ "ui header"] "Navigate up"
-          let forestB = G.obviateRootUnlessForest z $ G.dfsForestBackwards z graph
+          div_ [class_ "ui header"] "Parent backlinks"
           ul_ $ do
-            renderForest True Nothing LinkTheme_Simple graph forestB
+            renderForest True Nothing LinkTheme_Simple graph $
+              G.backlinkForest Folgezettel z graph
+          div_ [class_ "ui header"] "Other backlinks"
+          ul_ $ do
+            renderForest True Nothing LinkTheme_Simple graph
+              $ fmap (flip Node [])
+              $ G.backlinks OrdinaryConnection z graph
     div_ [class_ "ui inverted black bottom attached footer segment"] $ do
       div_ [class_ "ui equal width grid"] $ do
         div_ [class_ "center aligned column"] $ do
@@ -224,9 +227,9 @@ renderForest isRoot maxLevel ltheme g trees =
             renderZettelLink ltheme zettel
           when (ltheme == LinkTheme_Default) $ do
             " "
-            case G.backlinks zettel g of
+            case G.backlinks Folgezettel zettel g of
               conns@(_ : _ : _) ->
-                -- Has two or more backlinks
+                -- Has two or more backlinkForest
                 forM_ conns $ \zettel2 -> do
                   i_ [class_ "fas fa-link", title_ $ zettelIDText (zettelID zettel2) <> " " <> zettelTitle zettel2] mempty
               _ -> mempty

--- a/src/Neuron/Web/View.hs
+++ b/src/Neuron/Web/View.hs
@@ -150,11 +150,11 @@ renderZettel config@Config {..} (graph, (z@Zettel {..}, ext)) zid = do
     div_ [class_ $ "ui inverted " <> Theme.semanticColor neuronTheme <> " top attached connections segment"] $ do
       div_ [class_ "ui two column grid"] $ do
         div_ [class_ "column"] $ do
-          div_ [class_ "ui header"] "Children"
+          div_ [class_ "ui header"] "Down"
           ul_ $ renderForest True (Just 2) LinkTheme_Simple graph $
             G.frontlinkForest Folgezettel z graph
         div_ [class_ "column"] $ do
-          div_ [class_ "ui header"] "Parent backlinks"
+          div_ [class_ "ui header"] "Up"
           ul_ $ do
             renderForest True Nothing LinkTheme_Simple graph $
               G.backlinkForest Folgezettel z graph
@@ -229,7 +229,7 @@ renderForest isRoot maxLevel ltheme g trees =
             " "
             case G.backlinks Folgezettel zettel g of
               conns@(_ : _ : _) ->
-                -- Has two or more backlinkForest
+                -- Has two or more category backlinks
                 forM_ conns $ \zettel2 -> do
                   i_ [class_ "fas fa-link", title_ $ zettelIDText (zettelID zettel2) <> " " <> zettelTitle zettel2] mempty
               _ -> mempty

--- a/src/Neuron/Zettelkasten/Connection.hs
+++ b/src/Neuron/Zettelkasten/Connection.hs
@@ -6,9 +6,14 @@ import Relude
 
 -- | Represent the connection between zettels
 data Connection
-  = -- | A folgezettel points to a zettel that is conceptually a part of the
+  = -- | A folgezettel points to a zettel that is conceptually a *part* of the
     -- parent zettel.
     Folgezettel
   | -- | Any other ordinary connection (eg: "See also")
     OrdinaryConnection
   deriving (Eq, Ord, Show, Enum, Bounded)
+
+instance Semigroup Connection where
+  Folgezettel <> _ = Folgezettel
+  _ <> Folgezettel = Folgezettel
+  OrdinaryConnection <> OrdinaryConnection = OrdinaryConnection

--- a/src/Neuron/Zettelkasten/Connection.hs
+++ b/src/Neuron/Zettelkasten/Connection.hs
@@ -14,6 +14,7 @@ data Connection
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 instance Semigroup Connection where
+  -- A folgezettel link trumps all other kinds in that zettel.
   Folgezettel <> _ = Folgezettel
   _ <> Folgezettel = Folgezettel
   OrdinaryConnection <> OrdinaryConnection = OrdinaryConnection

--- a/src/Neuron/Zettelkasten/Graph.hs
+++ b/src/Neuron/Zettelkasten/Graph.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Zettelkasten.Graph
@@ -14,14 +14,25 @@ module Neuron.Zettelkasten.Graph
 
     -- * Construction
     loadZettelkasten,
+
+    -- * Graph functions
+    topSort,
+    frontlinkForest,
+    backlinkForest,
+    backlinks,
+    clusters,
+    categoryClusters,
+    getZettels,
   )
 where
 
 import Control.Monad.Except
 import Data.Dependent.Sum
-import Data.Graph.Labelled
+import Data.Foldable (maximum)
+import qualified Data.Graph.Labelled as G
 import qualified Data.Map.Strict as Map
 import Data.Traversable (for)
+import Data.Tree
 import Development.Shake (Action)
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Error
@@ -53,28 +64,56 @@ mkZettelGraph zettels = do
         withExcept (NeuronError_BadQuery (zettelID z)) $
           (z,) <$> evaluateQueries zettels z
   let zettelsWithExtensions = fmap (replaceLink . fmap renderQueryLink) <$> zettelsWithQueryResults
-      edges :: [([Connection], Zettel, Zettel)] = flip concatMap zettelsWithQueryResults $ \(z, qm) ->
-        let conns :: [([Connection], Zettel)] = concatMap getConnections $ Map.elems qm
-            connsFiltered = filter (connectionWhitelist . fst) conns
-         in flip fmap connsFiltered $ \(cs, z2) -> (cs, z, z2)
-  pure (mkGraphFrom zettels edges, zettelsWithExtensions)
+      edges :: [(Maybe Connection, Zettel, Zettel)] = flip concatMap zettelsWithQueryResults $ \(z, qm) ->
+        let conns :: [(Connection, Zettel)] = concatMap getConnections $ Map.elems qm
+         in flip fmap conns $ \(cs, z2) -> (Just cs, z, z2)
+  pure (G.mkGraphFrom zettels edges, zettelsWithExtensions)
   where
     -- TODO: Handle conflicts in edge monoid operation (same link but with
     -- different connection type), and consequently use a sensible type other
     -- than list.
-    getConnections :: DSum Query EvaluatedQuery -> [([Connection], Zettel)]
+    getConnections :: DSum Query EvaluatedQuery -> [(Connection, Zettel)]
     getConnections = \case
       Query_ZettelByID _ :=> EvaluatedQuery {..} ->
-        [([evaluatedQueryConnection], evaluatedQueryResult)]
+        [(evaluatedQueryConnection, evaluatedQueryResult)]
       Query_ZettelsByTag _ :=> EvaluatedQuery {..} ->
-        ([evaluatedQueryConnection],) <$> evaluatedQueryResult
+        (evaluatedQueryConnection,) <$> evaluatedQueryResult
       _ ->
         []
-    -- Exclude ordinary connection when building the graph
-    --
-    -- TODO: Build the graph with all connections, but induce a subgraph when
-    -- building category forests. This way we can still show ordinary
-    -- connetions in places (eg: a "backlinks" section) where they are
-    -- relevant. See #34
-    connectionWhitelist cs =
-      OrdinaryConnection `notElem` cs
+
+frontlinkForest :: Connection -> Zettel -> ZettelGraph -> Forest Zettel
+frontlinkForest conn z =
+  G.obviateRootUnlessForest z
+    . G.dfsForestFrom [z]
+    . G.induceOnEdge (== Just conn)
+
+backlinkForest :: Connection -> Zettel -> ZettelGraph -> Forest Zettel
+backlinkForest conn z =
+  G.obviateRootUnlessForest z
+    . G.dfsForestBackwards z
+    . G.induceOnEdge (== Just conn)
+
+backlinks :: Connection -> Zettel -> ZettelGraph -> [Zettel]
+backlinks conn z =
+  G.preSet z . G.induceOnEdge (== Just conn)
+
+categoryClusters :: ZettelGraph -> [Forest Zettel]
+categoryClusters (categoryGraph -> g) =
+  let cs :: [[Zettel]] = sortMothers $ clusters g
+   in flip fmap cs $ \zs -> G.dfsForestFrom zs g
+  where
+    -- Sort clusters with newer mother zettels appearing first.
+    sortMothers :: [NonEmpty Zettel] -> [[Zettel]]
+    sortMothers = sortOn (Down . maximum) . fmap (sortOn Down . toList)
+
+clusters :: ZettelGraph -> [NonEmpty Zettel]
+clusters = G.clusters . categoryGraph
+
+topSort :: ZettelGraph -> Either (NonEmpty Zettel) [Zettel]
+topSort = G.topSort . categoryGraph
+
+categoryGraph :: ZettelGraph -> ZettelGraph
+categoryGraph = G.induceOnEdge (== Just Folgezettel)
+
+getZettels :: ZettelGraph -> [Zettel]
+getZettels = G.getVertices

--- a/src/Neuron/Zettelkasten/Graph.hs
+++ b/src/Neuron/Zettelkasten/Graph.hs
@@ -69,9 +69,6 @@ mkZettelGraph zettels = do
          in flip fmap conns $ \(cs, z2) -> (Just cs, z, z2)
   pure (G.mkGraphFrom zettels edges, zettelsWithExtensions)
   where
-    -- TODO: Handle conflicts in edge monoid operation (same link but with
-    -- different connection type), and consequently use a sensible type other
-    -- than list.
     getConnections :: DSum Query EvaluatedQuery -> [(Connection, Zettel)]
     getConnections = \case
       Query_ZettelByID _ :=> EvaluatedQuery {..} ->

--- a/src/Neuron/Zettelkasten/Graph/Type.hs
+++ b/src/Neuron/Zettelkasten/Graph/Type.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -15,6 +12,7 @@ where
 import Data.Graph.Labelled
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Zettel
+import Relude
 
 -- | The Zettelkasten graph
-type ZettelGraph = LabelledGraph Zettel [Connection]
+type ZettelGraph = LabelledGraph Zettel (Maybe Connection)

--- a/src/Neuron/Zettelkasten/Graph/Type.hs
+++ b/src/Neuron/Zettelkasten/Graph/Type.hs
@@ -15,4 +15,9 @@ import Neuron.Zettelkasten.Zettel
 import Relude
 
 -- | The Zettelkasten graph
+--
+-- Edges are labelled with `Connection`; Maybe is used to provide the
+-- `Algebra.Graph.Label.zero` value for the edge label, which is `Nothing` in
+-- our case, and is effectively the same as there not being an edge between
+-- those vertices.
 type ZettelGraph = LabelledGraph Zettel (Maybe Connection)


### PR DESCRIPTION
Revamp the graph type to represent all types of links (zcf included), and show the full range of backlinks in connections panel (i.e., including zcf backlinks).

Resolves #34 