### PR TITLE
Add `neuron new --id-hash` for random hash IDs

### DIFF
--- a/neuron.cabal
+++ b/neuron.cabal
@@ -65,7 +65,8 @@ common library-common
     dependent-sum-template,
     aeson-gadt-th,
     parser-combinators,
-    data-default
+    data-default,
+    uuid,
 
 library
   import: library-common
@@ -90,6 +91,7 @@ library
     Neuron.Zettelkasten.Error
     Neuron.Zettelkasten.Graph
     Neuron.Zettelkasten.ID
+    Neuron.Zettelkasten.ID.Scheme
     Neuron.Zettelkasten.Query
     Neuron.Zettelkasten.Query.Eval
     Neuron.Zettelkasten.Query.Error

--- a/src-bin/Main.hs
+++ b/src-bin/Main.hs
@@ -29,7 +29,7 @@ generateMainSite = do
   config <- Config.getConfig
   let writeHtmlRoute :: Route g a -> (g, a) -> Action ()
       writeHtmlRoute r = Rib.writeRoute r . Lucid.renderText . renderPage config r
-  void $ generateSite config writeHtmlRoute ["*.md"]
+  void $ generateSite config writeHtmlRoute
 
 renderPage :: Config -> Route g a -> (g, a) -> Html ()
 renderPage config r val = html_ [lang_ "en"] $ do

--- a/src/Neuron/CLI/New.hs
+++ b/src/Neuron/CLI/New.hs
@@ -14,6 +14,7 @@ where
 import qualified Data.Set as Set
 import Data.Some
 import Data.Text (strip)
+import qualified Data.Text as T
 import Development.Shake (Action)
 import Neuron.CLI.Types
 import qualified Neuron.Zettelkasten.Graph as G
@@ -41,7 +42,16 @@ newZettelFile NewCommand {..} = do
       liftIO $ do
         fileAction :: FilePath -> IO () <-
           bool (pure showAction) mkEditActionFromEnv edit
-        writeFile path $ "---\ntitle: " <> toString title <> "\n---\n\n"
+        writeFileText path $
+          T.intercalate
+            "\n"
+            [ "---",
+              "title: " <> title,
+              "date: " <> show day,
+              "---",
+              "",
+              ""
+            ]
         fileAction path
   where
     mkEditActionFromEnv :: IO (FilePath -> IO ())

--- a/src/Neuron/CLI/New.hs
+++ b/src/Neuron/CLI/New.hs
@@ -11,13 +11,17 @@ module Neuron.CLI.New
   )
 where
 
+import qualified Data.Set as Set
+import Data.Some
 import Data.Text (strip)
 import Development.Shake (Action)
 import Neuron.CLI.Types
-import Neuron.Zettelkasten.ID (zettelNextId, zettelPath)
+import qualified Neuron.Zettelkasten.Graph as G
+import Neuron.Zettelkasten.ID (zettelPath)
+import qualified Neuron.Zettelkasten.ID.Scheme as IDScheme
+import Neuron.Zettelkasten.Zettel (zettelID)
 import Options.Applicative
 import Relude
-import System.Directory
 import qualified System.Posix.Env as Env
 import System.Posix.Process
 
@@ -26,14 +30,19 @@ import System.Posix.Process
 -- As well as print the path to the created file.
 newZettelFile :: NewCommand -> Action ()
 newZettelFile NewCommand {..} = do
-  path <- zettelPath =<< zettelNextId day
-  liftIO $ do
-    whenM (doesFileExist path) $
-      fail ("File already exists: " <> show path)
-    fileAction :: FilePath -> IO () <-
-      bool (pure showAction) mkEditActionFromEnv edit
-    writeFile path $ "---\ntitle: " <> toString title <> "\n---\n\n"
-    fileAction path
+  zettels <- G.loadZettels
+  mzid <- withSome idScheme $ \scheme -> do
+    val <- liftIO $ IDScheme.genVal scheme
+    pure $ IDScheme.nextAvailableZettelID (Set.fromList $ fmap zettelID zettels) val scheme
+  case mzid of
+    Left e -> die $ show e
+    Right zid -> do
+      path <- zettelPath zid
+      liftIO $ do
+        fileAction :: FilePath -> IO () <-
+          bool (pure showAction) mkEditActionFromEnv edit
+        writeFile path $ "---\ntitle: " <> toString title <> "\n---\n\n"
+        fileAction path
   where
     mkEditActionFromEnv :: IO (FilePath -> IO ())
     mkEditActionFromEnv =

--- a/src/Neuron/CLI/Query.hs
+++ b/src/Neuron/CLI/Query.hs
@@ -13,11 +13,9 @@ import Development.Shake (Action)
 import qualified Neuron.Zettelkasten.Graph as G
 import Neuron.Zettelkasten.Query (Query (..), queryResultJson, runQuery)
 import Relude
-import qualified Rib
 
 queryZettelkasten :: FilePath -> Some Query -> Action ()
-queryZettelkasten notesDir query = do
-  zettels <- fmap (fmap fst . snd) . G.loadZettelkasten =<< Rib.forEvery ["*.md"] pure
-  withSome query $ \q -> do
-    let result = runQuery zettels q
+queryZettelkasten notesDir =
+  foldSome $ \q -> do
+    result <- flip runQuery q <$> G.loadZettels
     putLTextLn $ Aeson.encodeToLazyText $ queryResultJson notesDir q result

--- a/src/Neuron/CLI/Types.hs
+++ b/src/Neuron/CLI/Types.hs
@@ -40,8 +40,7 @@ data NewCommand = NewCommand
     idScheme :: Some IDScheme,
     edit :: Bool
   }
-
--- deriving (Eq, Show)
+  deriving (Eq, Show)
 
 data SearchCommand = SearchCommand
   { searchBy :: SearchBy,

--- a/src/Neuron/Web/Generate.hs
+++ b/src/Neuron/Web/Generate.hs
@@ -18,20 +18,18 @@ import qualified Neuron.Zettelkasten.Graph as G
 import qualified Neuron.Zettelkasten.Zettel as Z
 import Options.Applicative
 import Relude
-import qualified Rib
 
 -- | Generate the Zettelkasten site
 generateSite ::
   Z.Config ->
   (forall a. Z.Route G.ZettelGraph a -> (G.ZettelGraph, a) -> Action ()) ->
-  [FilePath] ->
   Action G.ZettelGraph
-generateSite config writeHtmlRoute' zettelsPat = do
+generateSite config writeHtmlRoute' = do
   when (olderThan $ Z.minVersion config)
     $ fail
     $ toString
     $ "Require neuron mininum version " <> Z.minVersion config <> ", but your neuron version is " <> neuronVersion
-  (zettelGraph, zettels) <- G.loadZettelkasten =<< Rib.forEvery zettelsPat pure
+  (zettelGraph, zettels) <- G.loadZettelkasten
   let writeHtmlRoute v r = writeHtmlRoute' r (zettelGraph, v)
   -- Generate HTML for every zettel
   forM_ zettels $ \(z, d) ->

--- a/src/Neuron/Zettelkasten/Graph.hs
+++ b/src/Neuron/Zettelkasten/Graph.hs
@@ -13,7 +13,9 @@ module Neuron.Zettelkasten.Graph
     ZettelGraph,
 
     -- * Construction
+    loadZettels,
     loadZettelkasten,
+    loadZettelkastenFrom,
 
     -- * Graph functions
     topSort,
@@ -42,12 +44,21 @@ import Neuron.Zettelkasten.Query.Eval (EvaluatedQuery (..), evaluateQueries)
 import Neuron.Zettelkasten.Query.View (renderQueryLink)
 import Neuron.Zettelkasten.Zettel
 import Relude
+import qualified Rib
 import Text.MMark.Extension (Extension)
 import Text.MMark.Extension.ReplaceLink (replaceLink)
 
+loadZettels :: Action [Zettel]
+loadZettels =
+  fmap (fmap fst . snd) loadZettelkasten
+
+loadZettelkasten :: Action (ZettelGraph, [(Zettel, Extension)])
+loadZettelkasten =
+  loadZettelkastenFrom =<< Rib.forEvery ["*.md"] pure
+
 -- | Load the Zettelkasten from disk, using the given list of zettel files
-loadZettelkasten :: [FilePath] -> Action (ZettelGraph, [(Zettel, Extension)])
-loadZettelkasten files = do
+loadZettelkastenFrom :: [FilePath] -> Action (ZettelGraph, [(Zettel, Extension)])
+loadZettelkastenFrom files = do
   zettels <- mkZettelFromPath `mapM` files
   either (fail . show) pure $ mkZettelGraph zettels
 

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -13,7 +13,6 @@ module Neuron.Zettelkasten.ID
     parseZettelID',
     idParser,
     mkZettelID,
-    zettelNextId,
     zettelIDSourceFileName,
     zettelPath,
     customIDParser,
@@ -28,9 +27,7 @@ import Development.Shake (Action)
 import Lucid
 import Relude
 import qualified Rib
-import System.Directory (listDirectory)
 import System.FilePath
-import qualified System.FilePattern as FP
 import qualified Text.Megaparsec as M
 import qualified Text.Megaparsec.Char as M
 import Text.Megaparsec.Simple
@@ -81,21 +78,6 @@ zettelPath :: ZettelID -> Action FilePath
 zettelPath zid = do
   notesDir <- Rib.ribInputDir
   pure $ notesDir </> zettelIDSourceFileName zid
-
-zettelNextId :: Day -> Action ZettelID
-zettelNextId day = do
-  inputDir <- Rib.ribInputDir
-  let dayS = toString $ formatDay day
-  zettelFiles <- liftIO $ listDirectory inputDir
-  let nums :: [Int] =
-        sort $ mapMaybe readMaybe
-          $ catMaybes
-          $ mapMaybe (fmap listToMaybe . FP.match (dayS <> "*.md")) zettelFiles
-  case fmap last (nonEmpty nums) of
-    Just lastNum ->
-      pure $ ZettelDateID day (lastNum + 1)
-    Nothing ->
-      pure $ ZettelDateID day 1
 
 ---------
 -- Parser

--- a/src/Neuron/Zettelkasten/ID.hs
+++ b/src/Neuron/Zettelkasten/ID.hs
@@ -20,6 +20,7 @@ module Neuron.Zettelkasten.ID
   )
 where
 
+import Control.Monad.Except
 import Data.Aeson (ToJSON (toJSON))
 import qualified Data.Text as T
 import Data.Time

--- a/src/Neuron/Zettelkasten/ID/Scheme.hs
+++ b/src/Neuron/Zettelkasten/ID/Scheme.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.ID.Scheme where
+
+import Control.Monad.Except
+import Data.GADT.Compare.TH
+import Data.GADT.Show.TH
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Data.Time
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
+import Data.UUID.V4 (nextRandom)
+import Neuron.Zettelkasten.ID
+import Relude
+import Text.Megaparsec.Simple
+import Text.Show
+
+data IDScheme a where
+  IDSchemeDate :: Day -> IDScheme ()
+  IDSchemeHash :: IDScheme UUID
+  IDSchemeCustom :: Text -> IDScheme ()
+
+data IDConflict
+  = IDConflict_AlreadyExists
+  | IDConflict_DateIDExhausted
+  | IDConflict_HashConflict Text
+  | IDConflict_BadCustomID Text Text
+  deriving (Eq)
+
+instance Show IDConflict where
+  show = \case
+    IDConflict_AlreadyExists ->
+      "A zettel with that ID already exists"
+    IDConflict_DateIDExhausted ->
+      "Ran out of date ID indices for this day"
+    IDConflict_HashConflict s ->
+      "Hash conflict on " <> toString s <> "; try again"
+    IDConflict_BadCustomID s e ->
+      "The custom ID " <> toString s <> " is malformed: " <> toString e
+
+-- | Produce a value that is required to run an ID scheme.
+genVal :: forall a. IDScheme a -> IO a
+genVal = \case
+  IDSchemeHash ->
+    nextRandom
+  IDSchemeDate _ ->
+    pure ()
+  IDSchemeCustom _ ->
+    pure ()
+
+-- | Create a new zettel ID based on the given scheme without conflicting with
+-- the IDs of existing zettels.
+nextAvailableZettelID ::
+  forall a.
+  -- Existing zettels
+  Set ZettelID ->
+  a ->
+  IDScheme a ->
+  Either IDConflict ZettelID
+nextAvailableZettelID zs val = \case
+  IDSchemeDate day -> do
+    let dayIndices = nonEmpty $ sort $ flip mapMaybe (Set.toList zs) $ \case
+          ZettelDateID d x
+            | d == day -> Just x
+          _ -> Nothing
+    case last <$> dayIndices of
+      Nothing -> pure $ ZettelDateID day 1
+      Just 99 -> throwError IDConflict_DateIDExhausted
+      Just idx -> pure $ ZettelDateID day (idx + 1)
+  IDSchemeHash -> do
+    let s = T.take 8 $ UUID.toText val
+    if s `Set.member` (zettelIDText `Set.map` zs)
+      then throwError $ IDConflict_HashConflict s
+      else
+        either (error . toText) (pure . ZettelCustomID) $
+          parse customIDParser "<random-hash>" s
+  IDSchemeCustom s -> runExcept $ do
+    zid <-
+      either (throwError . IDConflict_BadCustomID s) (pure . ZettelCustomID) $
+        parse customIDParser "<next-id>" s
+    if zid `Set.member` zs
+      then throwError IDConflict_AlreadyExists
+      else pure zid
+
+deriveGEq ''IDScheme
+
+deriveGShow ''IDScheme

--- a/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
+++ b/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.ID.SchemeSpec
+  ( spec,
+  )
+where
+
+import qualified Data.Set as Set
+import Data.Time
+import Neuron.Zettelkasten.ID
+import Neuron.Zettelkasten.ID.Scheme
+import Relude
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "nextAvailableZettelID" $ do
+    let zettels =
+          Set.fromList $
+            fmap
+              parseZettelID
+              [ "ribeye-steak",
+                "2015403"
+              ]
+        day = fromGregorian 2020 4 16
+        nextAvail scheme = do
+          v <- genVal scheme
+          pure $ nextAvailableZettelID zettels v scheme
+    context "custom ID" $ do
+      it "checks if already exists" $ do
+        nextAvail (IDSchemeCustom "ribeye-steak")
+          `shouldReturn` Left IDConflict_AlreadyExists
+      it "succeeds" $ do
+        nextAvail (IDSchemeCustom "sunny-side-eggs")
+          `shouldReturn` Right (ZettelCustomID "sunny-side-eggs")
+    context "date ID" $ do
+      it "should return index 0" $ do
+        let otherDay = fromGregorian 2020 5 16
+        nextAvail (IDSchemeDate otherDay)
+          `shouldReturn` Right (ZettelDateID otherDay 1)
+      it "should return correct index" $
+        nextAvail (IDSchemeDate day)
+          `shouldReturn` Right (ZettelDateID day 4)
+    context "hash ID" $ do
+      it "should succeed" $
+        nextAvail IDSchemeHash
+          >>= (`shouldNotSatisfy` isLeft)


### PR DESCRIPTION
Also adds `--id=<custom>` and `--id-date`. 

Date ID is still the default .

And `neuron new` adds the creation date to the zettel metadata regardless of the ID scheme used.

For #151 
