### PR TITLE
Raw HTML support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - With this change, neuron can potentially support other text formats (org,
     reST, etc.)
 - Switch to GHC 8.6 (for reflex-dom)
+- Raw HTML support (#191)
 
 ## 0.4.0.0
 

--- a/dep/reflex-dom-pandoc/github.json
+++ b/dep/reflex-dom-pandoc/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "srid",
   "repo": "reflex-dom-pandoc",
-  "branch": "rawhtml",
+  "branch": "master",
   "private": false,
-  "rev": "92ba20295611451bbd142572de7a2ff325c932af",
-  "sha256": "0ma52n9ahcspb023d429nwiqxdqn88y5b2hdfdvmhnqzvbcz9i0q"
+  "rev": "2fb4d7c9201d39c4a23e8e7067f36474674c22cd",
+  "sha256": "06l7a2rs7xi14d5nqz873pvl270vdhi863b7axxi6n6ybzzif2rr"
 }

--- a/dep/reflex-dom-pandoc/github.json
+++ b/dep/reflex-dom-pandoc/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "srid",
   "repo": "reflex-dom-pandoc",
-  "branch": "master",
+  "branch": "rawhtml",
   "private": false,
-  "rev": "71ec620dcefdeef3aa2618a257b936fa5b27d65d",
-  "sha256": "1qwchjlv8r1kqcync3qba0f3admzbx99qfj6fhwn83xfk7mb9rwj"
+  "rev": "92ba20295611451bbd142572de7a2ff325c932af",
+  "sha256": "0ma52n9ahcspb023d429nwiqxdqn88y5b2hdfdvmhnqzvbcz9i0q"
 }

--- a/src/app/Main.hs
+++ b/src/app/Main.hs
@@ -18,6 +18,7 @@ import Neuron.Web.Generate (generateSite)
 import Neuron.Web.Route (Route (..))
 import Neuron.Web.View (renderRouteBody, renderRouteHead, style)
 import Reflex.Dom.Core
+import Reflex.Dom.Pandoc.Document (PandocBuilder)
 import Relude
 import qualified Rib
 
@@ -35,7 +36,7 @@ generateMainSite = do
         Rib.writeRoute r $ decodeUtf8 @Text html
   void $ generateSite config writeHtmlRoute
 
-renderPage :: DomBuilder t m => Config -> Route g a -> (g, a) -> m ()
+renderPage :: PandocBuilder t m => Config -> Route g a -> (g, a) -> m ()
 renderPage config r val = elAttr "html" ("lang" =: "en") $ do
   el "head" $ do
     renderRouteHead config r val

--- a/src/app/Neuron/Web/View.hs
+++ b/src/app/Neuron/Web/View.hs
@@ -45,6 +45,7 @@ import Neuron.Zettelkasten.ID (ZettelID (..), zettelIDSourceFileName, zettelIDTe
 import Neuron.Zettelkasten.Zettel
 import qualified Neuron.Zettelkasten.Zettel.View as ZettelView
 import Reflex.Dom.Core
+import Reflex.Dom.Pandoc.Document (PandocBuilder)
 import Relude
 import qualified Rib
 import Rib.Extra.OpenGraph
@@ -121,7 +122,7 @@ renderOpenGraph OpenGraph {..} = do
         then f $ URI.render uri'
         else error $ description <> " must be absolute. this URI is not: " <> URI.render uri'
 
-renderRouteBody :: DomBuilder t m => Config -> Route graph a -> (graph, a) -> m ()
+renderRouteBody :: PandocBuilder t m => Config -> Route graph a -> (graph, a) -> m ()
 renderRouteBody config r (g, x) = do
   case r of
     Route_ZIndex ->
@@ -181,7 +182,7 @@ renderSearch graph = do
   el "script" $ text $ "let index = " <> toText (Aeson.encodeToLazyText index) <> ";"
   el "script" $ text searchScript
 
-renderZettel :: DomBuilder t m => Config -> (ZettelGraph, Zettel) -> m ()
+renderZettel :: PandocBuilder t m => Config -> (ZettelGraph, Zettel) -> m ()
 renderZettel config (graph, z@Zettel {..}) = do
   divClass "zettel-view" $ do
     ZettelView.renderZettelContent z

--- a/src/lib/Neuron/Markdown.hs
+++ b/src/lib/Neuron/Markdown.hs
@@ -138,6 +138,7 @@ neuronSpec =
       CE.mathSpec,
       CE.smartPunctuationSpec,
       CE.attributesSpec,
+      CE.rawAttributeSpec,
       CM.defaultSyntaxSpec {CM.syntaxBlockSpecs = defaultBlockSpecsSansRawHtml}
     ]
   where

--- a/src/lib/Neuron/Zettelkasten/Query/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Query/View.hs
@@ -135,7 +135,7 @@ buildQueryView = \case
 -- TODO: not using Rib for ghcjs, but factorize this
 zettelUrl :: ZettelID -> Text
 zettelUrl zid =
-  "/" <> zettelIDText zid <> ".html"
+  zettelIDText zid <> ".html"
 
 tagUrl :: Tag -> Text
 tagUrl (Tag s) =

--- a/src/lib/Neuron/Zettelkasten/Zettel/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Zettel/View.hs
@@ -30,7 +30,7 @@ renderZettelContent :: PandocBuilder t m => Zettel -> m ()
 renderZettelContent Zettel {..} = do
   divClass "ui raised segment zettel-content" $ do
     elClass "h1" "header" $ text zettelTitle
-    elPandocDoc zettelContent
+    elPandoc zettelContent
     renderTags zettelTags
     whenJust zettelDay $ \day ->
       elAttr "div" ("class" =: "date" <> "title" =: "Zettel creation date") $ text $ show day

--- a/src/lib/Neuron/Zettelkasten/Zettel/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Zettel/View.hs
@@ -26,7 +26,7 @@ import Reflex.Dom.Core
 import Reflex.Dom.Pandoc.Document
 import Relude
 
-renderZettelContent :: DomBuilder t m => Zettel -> m ()
+renderZettelContent :: PandocBuilder t m => Zettel -> m ()
 renderZettelContent Zettel {..} = do
   divClass "ui raised segment zettel-content" $ do
     elClass "h1" "header" $ text zettelTitle


### PR DESCRIPTION
HTML elements must provide an explicit list of attributes (so as to disambiguate from zettel links). Actual work happens at https://github.com/srid/reflex-dom-pandoc/pull/1