### PR TITLE
Revamp "connections panel" with something entirely different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     reST, etc.)
 - Switch to GHC 8.6 (for reflex-dom)
 - Raw HTML support (#191)
+- Introduce new "uplink tree" view (#195)
 - Bug fixes
   - Fix 'neuron new' generating invalid Markdown when title contains special characters (#163)
 

--- a/guide/2011503.md
+++ b/guide/2011503.md
@@ -2,13 +2,12 @@
 title: Graph view
 ---
 
-A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_graph), and <2017401> is a subset of this graph established using special links.
+A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_graph), and <2017401> is a subset of this graph established by having zettels branch off to other zettels.
 
 ## z-index 
 
-The z-index page (at `/z-index.html`; also linked in the footer) displays your Zettelkasten graph. It detects clusters in the graph, and renders each of them as a forest; see <2012301>.
+The z-index page (at `/z-index.html`; also linked in the footer) displays your Zettelkasten graph. Neuron detects if there are any cycles in your Zettelkasten graph (use `cf` to resolve cycles). Then, it detects all <2012301> in the graph, and displays the <2017401> for each cluster.
 
-## Connections
+## Uplinks and Backlinks
 
-Each zettel has a "connection" pane at the bottom. It shows both the children and the parent connections to other zettels (as defined by <2017401> connections), as well the backlinks not part of the tree. 
-
+Uplinks are a kind of backlinks. Specifically an uplink tree of a zettel is the subset of the category tree which branch off to the zettel. Uplink tree is displayed above the zettel; other backlinks are displayed below.

--- a/guide/2013101.md
+++ b/guide/2013101.md
@@ -9,9 +9,6 @@ Here is a list of public Zettelkastens that are managed by neuron:
 - [haskell.zettel.page](https://haskell.zettel.page) ([source](https://github.com/srid/haskell-zettelkasten)): A public Zettekasten for the [Haskell](https://www.haskell.org/) community.
 - [www.srid.ca](https://www.srid.ca/)
   ([source](https://github.com/srid/srid.ca)): Personal homepage of Srid; a demonstration of using Neuron for creating your personal website.
-- [emacs.zettel.page](https://emacs.zettel.page)
-  ([source](https://github.com/srid/emacs.zettel.page)): A public Zettekasten
-  for Emacs (still in its infancy)
 - [rib.srid.ca](https://rib.srid.ca/) ([source](https://github.com/srid/rib/tree/master/guide)): Rib project website.
 
 If you are hosting your own Zettelkasten publicly and would like to include it in this list, edit this page (using the link below) to open a pull request.

--- a/guide/2017401.md
+++ b/guide/2017401.md
@@ -2,9 +2,9 @@
 title: Category Tree
 ---
 
-Neuron allows you to organically build a category tree out of your Zettelkasten graph. This is achieved by <2011504?cf> without the `cf` flag. First, Neuron detects if there are any cycles in your Zettelkasten graph (use `cf` to resolve cycles). Then, it detects all clusters in the graph, and displays a tree view (aka. 'category tree') for each cluster.
+Neuron allows you to organically build a hierarchy out of your Zettelkasten over time. This is achieved by <2011504?cf> *without* the `cf` flag. When a zettel links to another, it "branches of" to that zettel ... unless `cf` is used (in which case it is not a branch off). 
 
-The category tree is displayed in the z-index, as well as the connections panel of each zettel.
+**Uplink trees** are a kind of category tree that display all zettels that branch off to a particular zettel. The uplink tree of a zettel is displayed at the top of each zettel page.
 
 ## See also
 

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.5.0.0
+version: 0.5.1.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/src/app/Main.hs
+++ b/src/app/Main.hs
@@ -45,7 +45,7 @@ renderPage config r val = elAttr "html" ("lang" =: "en") $ do
         blank
       _ -> do
         forM_
-          [ "https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css",
+          [ "https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css",
             "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"
           ]
           $ \url ->

--- a/src/app/Main.hs
+++ b/src/app/Main.hs
@@ -55,7 +55,7 @@ renderPage config r val = elAttr "html" ("lang" =: "en") $ do
         when (Config.mathJaxSupport config) $
           elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
   el "body" $ do
-    elAttr "div" ("id" =: "thesite" <> "class" =: "ui text container") $ do
+    elAttr "div" ("id" =: "thesite" <> "class" =: "ui fluid container") $ do
       renderRouteBody config r val
   where
     googleFonts :: DomBuilder t m => [Text] -> m ()
@@ -74,16 +74,19 @@ monoFont :: Text
 monoFont = "DM Mono"
 
 mainStyle :: Config -> Css
-mainStyle cfg = "div#thesite" ? do
-  C.fontFamily [bodyFont] [C.serif]
-  C.paddingTop $ em 1
-  C.paddingBottom $ em 1
-  "p" ? do
-    C.lineHeight $ pct 150
-  "h1, h2, h3, h4, h5, h6, .ui.header, .headerFont" ? do
-    C.fontFamily [headerFont] [C.sansSerif]
-  "img" ? do
-    C.maxWidth $ pct 100 -- Prevents large images from overflowing beyond zettel borders
-  "code, pre, tt, .monoFont" ? do
-    C.fontFamily [monoFont, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New"] [C.monospace]
-  style cfg
+mainStyle cfg = do
+  "body" ? do
+    C.important $ C.backgroundColor "#eee"
+  "div#thesite" ? do
+    C.fontFamily [bodyFont] [C.serif]
+    C.paddingTop $ em 1
+    C.paddingBottom $ em 1
+    "p" ? do
+      C.lineHeight $ pct 150
+    "h1, h2, h3, h4, h5, h6, .ui.header, .headerFont" ? do
+      C.fontFamily [headerFont] [C.sansSerif]
+    "img" ? do
+      C.maxWidth $ pct 100 -- Prevents large images from overflowing beyond zettel borders
+    "code, pre, tt, .monoFont" ? do
+      C.fontFamily [monoFont, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New"] [C.monospace]
+    style cfg

--- a/src/app/Neuron/Web/View.hs
+++ b/src/app/Neuron/Web/View.hs
@@ -351,6 +351,8 @@ style Config {..} = do
   ".footer-version" ? do
     C.fontSize $ em 0.7
   pureCssTreeDiagram
+  ".backlinks:hover" ? do
+    opacity 1
   ".backlinks" ? do
     opacity 0.5
 
@@ -362,8 +364,11 @@ pureCssTreeDiagram = do
       rotateDeg = deg 180
   ".tree.flipped" ? do
     C.transform $ C.rotate rotateDeg
+  ".tree:hover" ? do
+    C.opacity 1
   ".tree" ? do
     C.overflow auto
+    C.opacity 0.5
     fontSize $ em 0.9
     when flipTree $ do
       C.transform $ C.rotate rotateDeg
@@ -432,7 +437,7 @@ pureCssTreeDiagram = do
     "li" ? do
       "div.forest-link" ? do
         border solid cellBorderWidth "#ccc"
-        sym2 C.padding (em 0.5) (em 0.75)
+        sym2 C.padding (em 0.2) (em 0.3)
         C.textDecoration none
         C.display inlineBlock
         sym C.borderRadius (px 5)

--- a/src/app/Neuron/Web/View.hs
+++ b/src/app/Neuron/Web/View.hs
@@ -209,45 +209,14 @@ renderZettel config (graph, z@Zettel {..}) = do
           renderForest True Nothing Nothing $
             fmap (flip Node []) cfBacklinks
       renderFooter config graph (Just z)
+  renderBrandFooter
   -- Because the tree above can be pretty large, we scroll past it
   -- automatically when the page loads.
   -- TODO: Do this only if we have rendered the tree.
+  -- FIXME: This may not scroll sufficiently if the images in the zettel haven't
+  -- loaded (thus the browser doesn't known the final height yet.)
   el "script" $ text $
     "document.getElementById(\"zettel-container-anchor\").scrollIntoView({behavior: \"smooth\", block: \"start\"});"
-  -- renderZettelPanel config graph z
-  -- elAttr "div" ("class" =: "tree" <> "style" =: "transform-origin: 50%") $ do
-  --   el "ul" $ do
-  --     el "li" $ do
-  --       divClass "forest-link" $ el "a" $ text zettelTitle
-  --       el "ul" $ do
-  --         renderForestNG True (Just 2) Nothing $ G.frontlinkForest Folgezettel z graph
-  renderBrandFooter
-
-_renderZettelPanel :: DomBuilder t m => Config -> ZettelGraph -> Zettel -> m ()
-_renderZettelPanel config@Config {..} graph z@Zettel {..} = do
-  let neuronTheme = Theme.mkTheme theme
-  divClass ("ui inverted " <> Theme.semanticColor neuronTheme <> " top attached connections segment") $ do
-    divClass "ui two column grid" $ do
-      divClass "column" $ do
-        elAttr "div" ("class" =: "ui header" <> title =: "The following zettels branch to this zettel") $
-          text "Uplinks"
-        el "ul" $ do
-          renderForest True Nothing Nothing $
-            G.backlinkForest Folgezettel z graph
-        let cfBacklinks = G.backlinks OrdinaryConnection z graph
-        whenNotNull cfBacklinks $ \_ -> do
-          elAttr "div" ("class" =: "ui header" <> title =: "Zettels that link here, but without branching") $
-            text "Backlinks"
-          el "ul" $ do
-            renderForest True Nothing Nothing $
-              fmap (flip Node []) cfBacklinks
-      divClass "column" $ do
-        elAttr "div" ("class" =: "ui header" <> title =: "This zettel branches to the following zettels") $
-          text "Downlinks"
-        el "ul" $ renderForest True (Just 2) Nothing $
-          G.frontlinkForest Folgezettel z graph
-  renderFooter config graph (Just z)
-  renderBrandFooter
 
 renderFooter :: DomBuilder t m => Config -> ZettelGraph -> Maybe Zettel -> m ()
 renderFooter Config {..} graph mzettel = do

--- a/src/app/Neuron/Web/View.hs
+++ b/src/app/Neuron/Web/View.hs
@@ -201,7 +201,7 @@ renderZettel config (graph, z@Zettel {..}) = do
       let cfBacklinks = G.backlinks OrdinaryConnection z graph
       whenNotNull cfBacklinks $ \_ -> divClass "ui attached segment backlinks" $ do
         elAttr "div" ("class" =: "ui header" <> title =: "Zettels that link here, but without branching") $
-          text "Backlinks"
+          text "More backlinks"
         el "ul" $ do
           renderForest True Nothing Nothing $
             fmap (flip Node []) cfBacklinks

--- a/src/app/Neuron/Web/View.hs
+++ b/src/app/Neuron/Web/View.hs
@@ -189,13 +189,16 @@ renderZettel :: PandocBuilder t m => Config -> (ZettelGraph, Zettel) -> m ()
 renderZettel config (graph, z@Zettel {..}) = do
   let upTree = G.backlinkForest Folgezettel z graph
   whenNotNull upTree $ \_ -> do
-    elAttr "div" ("class" =: "flipped tree" <> "style" =: "transform-origin: 50%") $ do
+    elAttr "div" ("class" =: "flipped tree" <> "id" =: "zettel-uptree" <> "style" =: "transform-origin: 50%") $ do
       el "ul" $ do
         el "li" $ do
           divClass "forest-link" $ el "a" $ text zettelTitle
           el "ul" $ do
             renderForestNG True Nothing Nothing upTree
-  divClass "ui text container" $ do
+  elAttr "div" ("class" =: "ui text container" <> "id" =: "zettel-container" <> "style" =: "position: relative") $ do
+    -- zettel-container-anchor is a trick used by the scrollIntoView JS below
+    -- cf. https://stackoverflow.com/a/49968820/55246
+    elAttr "div" ("id" =: "zettel-container-anchor" <> "style" =: "position: absolute; top: -14px; left: 0") blank
     divClass "zettel-view" $ do
       ZettelView.renderZettelContent z
       let cfBacklinks = G.backlinks OrdinaryConnection z graph
@@ -206,6 +209,11 @@ renderZettel config (graph, z@Zettel {..}) = do
           renderForest True Nothing Nothing $
             fmap (flip Node []) cfBacklinks
       renderFooter config graph (Just z)
+  -- Because the tree above can be pretty large, we scroll past it
+  -- automatically when the page loads.
+  -- TODO: Do this only if we have rendered the tree.
+  el "script" $ text $
+    "document.getElementById(\"zettel-container-anchor\").scrollIntoView({behavior: \"smooth\", block: \"start\"});"
   -- renderZettelPanel config graph z
   -- elAttr "div" ("class" =: "tree" <> "style" =: "transform-origin: 50%") $ do
   --   el "ul" $ do

--- a/src/app/Neuron/Zettelkasten/Graph.hs
+++ b/src/app/Neuron/Zettelkasten/Graph.hs
@@ -95,8 +95,10 @@ backlinkForest conn z =
     . G.induceOnEdge (== Just conn)
 
 backlinks :: Connection -> Zettel -> ZettelGraph -> [Zettel]
-backlinks conn z =
-  G.preSet z . G.induceOnEdge (== Just conn)
+backlinks conn z g =
+  filter (not . branches) $ G.preSet z $ G.induceOnEdge (== Just conn) g
+  where
+    branches bz = G.hasEdge g z bz
 
 categoryClusters :: ZettelGraph -> [Forest Zettel]
 categoryClusters (categoryGraph -> g) =

--- a/src/app/Neuron/Zettelkasten/Graph.hs
+++ b/src/app/Neuron/Zettelkasten/Graph.hs
@@ -17,6 +17,7 @@ module Neuron.Zettelkasten.Graph
     -- * Graph functions
     getZettels,
     getZettel,
+    getConnection,
     topSort,
     frontlinkForest,
     backlinkForest,
@@ -28,6 +29,7 @@ where
 
 import Control.Monad.Except (MonadError, liftEither, runExceptT, withExceptT)
 import Control.Monad.Writer (runWriterT)
+import Data.Default
 import Data.Foldable (maximum)
 import qualified Data.Graph.Labelled as G
 import Data.Traversable (for)
@@ -123,3 +125,7 @@ getZettels = G.getVertices
 
 getZettel :: ZettelID -> ZettelGraph -> Maybe Zettel
 getZettel = G.findVertex
+
+-- | If no connection exists, this returns Nothing.
+getConnection :: Zettel -> Zettel -> ZettelGraph -> Maybe Connection
+getConnection z1 z2 g = fmap (fromMaybe def) $ G.edgeLabel g z1 z2

--- a/src/lib/Data/Graph/Labelled.hs
+++ b/src/lib/Data/Graph/Labelled.hs
@@ -12,6 +12,7 @@ module Data.Graph.Labelled
     findVertex,
     getVertices,
     hasEdge,
+    edgeLabel,
 
     -- * Algorithms
     preSet,

--- a/src/lib/Data/Graph/Labelled.hs
+++ b/src/lib/Data/Graph/Labelled.hs
@@ -11,6 +11,7 @@ module Data.Graph.Labelled
     -- * Querying
     findVertex,
     getVertices,
+    hasEdge,
 
     -- * Algorithms
     preSet,

--- a/src/lib/Data/Graph/Labelled/Algorithm.hs
+++ b/src/lib/Data/Graph/Labelled/Algorithm.hs
@@ -28,6 +28,10 @@ getVertices :: LabelledGraph v e -> [v]
 getVertices (LabelledGraph _ lm) =
   Map.elems lm
 
+hasEdge :: (Ord (VertexID v), Vertex v) => LabelledGraph v e -> v -> v -> Bool
+hasEdge (LabelledGraph g _) x y =
+  LAM.hasEdge (vertexID x) (vertexID y) g
+
 -- | Return the backlinks to the given vertex
 preSet :: (Vertex v, Ord (VertexID v)) => v -> LabelledGraph v e -> [v]
 preSet (vertexID -> zid) g =

--- a/src/lib/Data/Graph/Labelled/Algorithm.hs
+++ b/src/lib/Data/Graph/Labelled/Algorithm.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -31,6 +32,11 @@ getVertices (LabelledGraph _ lm) =
 hasEdge :: (Ord (VertexID v), Vertex v) => LabelledGraph v e -> v -> v -> Bool
 hasEdge (LabelledGraph g _) x y =
   LAM.hasEdge (vertexID x) (vertexID y) g
+
+edgeLabel :: (Monoid e, Ord (VertexID v), Vertex v) => LabelledGraph v e -> v -> v -> Maybe e
+edgeLabel lg@(LabelledGraph g _) x y = do
+  guard $ hasEdge lg x y
+  pure $ LAM.edgeLabel (vertexID x) (vertexID y) g
 
 -- | Return the backlinks to the given vertex
 preSet :: (Vertex v, Ord (VertexID v)) => v -> LabelledGraph v e -> [v]

--- a/src/lib/Neuron/Zettelkasten/Connection.hs
+++ b/src/lib/Neuron/Zettelkasten/Connection.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Zettelkasten.Connection where
 
 import Data.Aeson (ToJSON)
-import Relude
+import Data.Default
+import Relude hiding (show)
+import Text.Show
 
 -- | Represent the connection between zettels
 data Connection
@@ -14,10 +17,18 @@ data Connection
     Folgezettel
   | -- | Any other ordinary connection (eg: "See also")
     OrdinaryConnection
-  deriving (Eq, Ord, Show, Enum, Bounded, Generic, ToJSON)
+  deriving (Eq, Ord, Enum, Bounded, Generic, ToJSON)
 
 instance Semigroup Connection where
   -- A folgezettel link trumps all other kinds in that zettel.
   Folgezettel <> _ = Folgezettel
   _ <> Folgezettel = Folgezettel
   OrdinaryConnection <> OrdinaryConnection = OrdinaryConnection
+
+instance Default Connection where
+  def = Folgezettel
+
+instance Show Connection where
+  show = \case
+    Folgezettel -> "folgezettel"
+    OrdinaryConnection -> "cf"

--- a/src/lib/Neuron/Zettelkasten/Zettel/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Zettel/View.hs
@@ -28,7 +28,7 @@ import Relude
 
 renderZettelContent :: PandocBuilder t m => Zettel -> m ()
 renderZettelContent Zettel {..} = do
-  divClass "ui raised segment zettel-content" $ do
+  divClass "ui raised top attached segment zettel-content" $ do
     elClass "h1" "header" $ text zettelTitle
     elPandoc zettelContent
     renderTags zettelTags

--- a/src/lib/Neuron/Zettelkasten/Zettel/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Zettel/View.hs
@@ -10,6 +10,7 @@ module Neuron.Zettelkasten.Zettel.View
   ( renderZettelContent,
     renderZettelLink,
     zettelCss,
+    zettelLinkCss,
   )
 where
 
@@ -82,6 +83,25 @@ renderZettelLink conn (fromMaybe def -> LinkView {..}) Zettel {..} = do
             <> "data-inverted" =: ""
             <> "data-position" =: "right center"
         )
+
+zettelLinkCss :: Theme.Theme -> Css
+zettelLinkCss neuronTheme = do
+  let linkColor = Theme.withRgb neuronTheme C.rgb
+  "span.zettel-link-container span.zettel-link a" ? do
+    C.fontWeight C.bold
+    C.color linkColor
+    C.textDecoration C.none
+  "span.zettel-link-container span.zettel-link a:hover" ? do
+    C.backgroundColor linkColor
+    C.color C.white
+  "span.zettel-link-container span.extra" ? do
+    C.color C.auto
+    C.paddingRight $ em 0.3
+  "span.zettel-link-container.folgezettel::after" ? do
+    C.paddingLeft $ em 0.3
+    C.content $ C.stringContent "ᛦ"
+  "[data-tooltip]:after" ? do
+    C.fontSize $ em 0.7
 
 zettelCss :: Theme.Theme -> Css
 zettelCss neuronTheme = do

--- a/src/lib/Neuron/Zettelkasten/Zettel/View.hs
+++ b/src/lib/Neuron/Zettelkasten/Zettel/View.hs
@@ -19,6 +19,7 @@ import qualified Clay as C
 import Data.TagTree
 import qualified Data.Text as T
 import qualified Neuron.Web.Theme as Theme
+import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Query.Theme (LinkView (..))
 import Neuron.Zettelkasten.Query.View (tagUrl, zettelUrl)
 import Neuron.Zettelkasten.Zettel
@@ -52,9 +53,10 @@ renderTags tags = do
     el "p" blank
 
 -- | Render a link to an individual zettel.
-renderZettelLink :: DomBuilder t m => Maybe LinkView -> Zettel -> m ()
-renderZettelLink (fromMaybe def -> LinkView {..}) Zettel {..} = do
-  let mextra =
+renderZettelLink :: DomBuilder t m => Maybe Connection -> Maybe LinkView -> Zettel -> m ()
+renderZettelLink conn (fromMaybe def -> LinkView {..}) Zettel {..} = do
+  let connClass = maybe "" show conn
+      mextra =
         if linkViewShowDate
           then case zettelDay of
             Just day ->
@@ -62,7 +64,7 @@ renderZettelLink (fromMaybe def -> LinkView {..}) Zettel {..} = do
             Nothing ->
               Nothing
           else Nothing
-  elClass "span" "zettel-link-container" $ do
+  elClass "span" ("zettel-link-container " <> connClass) $ do
     forM_ mextra $ \extra ->
       elClass "span" "extra monoFont" $ text extra
     let linkTooltip =

--- a/test/Neuron/VersionSpec.hs
+++ b/test/Neuron/VersionSpec.hs
@@ -29,9 +29,9 @@ spec = do
     it "full versions" $ do
       "0.6.1.2" `isGreater` olderThan
       "0.5.3" `isGreater` olderThan
-      "0.5.1.8" `isGreater` olderThan
-      "0.5.0.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.2.8" `isGreater` olderThan
+      "0.5.1.0" `isLesserOrEqual` olderThan -- This is current version
       "0.3.1.0" `isLesserOrEqual` olderThan
     it "within same major version" $ do
-      "0.5.1.8" `isGreater` olderThan
-      "0.5.0.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.2.8" `isGreater` olderThan
+      "0.5.1.0" `isLesserOrEqual` olderThan -- This is current version


### PR DESCRIPTION
This is a major UI change. 

- [x] Inverse tree view, positioned _above_ zettels, as improvement over 'Up' links
- [x] Drop connections panel
- [x] Retain backlinks, but dimmed
- [x] Lift container width, but only for the inverse tree view.
- [x] Is the tree on top bothersome in regards to space (esp. for simple zettelkastens)?
  - ~~[ ] Consider folding it with a linear breadcrumb as [accordion](https://semantic-ui.com/modules/accordion.html)?~~
  - ~~[ ] Or use dual UI (tree vs linear breadcrumbs), picking one from neuron.dhall~~
  - [x] Scroll past the tree on page load
- [x] Use the folgezettel unicode branch icon (rendered next to zettel link) only in folgezettel links 
  - This addresses the removal of 'Down' links
- [ ] Figure out if the z-index tree can be improved
- [x] Refactor
- [x] Docs and terminology