### PR TITLE
Add: `neuron query --graph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Raw HTML support (#191)
 - Introduce new "uplink tree" view (#195)
 - Resilient error handling (#202)
+- Added `neuron query --graph` to get the entire graph as JSON export
 - Bug fixes
   - Fix 'neuron new' generating invalid Markdown when title contains special characters (#163)
 

--- a/neuron/src/app/Neuron/CLI.hs
+++ b/neuron/src/app/Neuron/CLI.hs
@@ -67,11 +67,11 @@ runWith act App {..} =
         case eSomeQ of
           Left someQ ->
             withSome someQ $ \q -> do
-              let result = Q.runQuery (G.getZettels graph) q
+              let result = Q.runZettelQuery (G.getZettels graph) q
               putLTextLn $ Aeson.encodeToLazyText $ Q.queryResultJson notesDir q result errors
           Right someQ ->
             withSome someQ $ \q -> do
-              let result = Q.runQueryGraph graph q
-              putLTextLn $ Aeson.encodeToLazyText $ Q.queryGraphResultJson q result errors
+              let result = Q.runGraphQuery graph q
+              putLTextLn $ Aeson.encodeToLazyText $ Q.graphQueryResultJson q result errors
     Search searchCmd ->
       interactiveSearch notesDir searchCmd

--- a/neuron/src/app/Neuron/CLI.hs
+++ b/neuron/src/app/Neuron/CLI.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -60,11 +61,17 @@ runWith act App {..} =
         putStrLn indexHtmlPath
         let opener = if os == "darwin" then "open" else "xdg-open"
         liftIO $ executeFile opener True [indexHtmlPath] Nothing
-    Query someQ ->
+    Query eSomeQ ->
       runRibOnceQuietly notesDir $ do
-        withSome someQ $ \q -> do
-          (graph, _, errors) <- Gen.loadZettelkasten
-          let result = Q.runQuery (G.getZettels graph) q
-          putLTextLn $ Aeson.encodeToLazyText $ Q.queryResultJson notesDir q result errors
+        (graph, _, errors) <- Gen.loadZettelkasten
+        case eSomeQ of
+          Left someQ ->
+            withSome someQ $ \q -> do
+              let result = Q.runQuery (G.getZettels graph) q
+              putLTextLn $ Aeson.encodeToLazyText $ Q.queryResultJson notesDir q result errors
+          Right someQ ->
+            withSome someQ $ \q -> do
+              let result = Q.runQueryGraph graph q
+              putLTextLn $ Aeson.encodeToLazyText $ Q.queryGraphResultJson q result errors
     Search searchCmd ->
       interactiveSearch notesDir searchCmd

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -65,7 +65,7 @@ data Command
   | -- | Search a zettel by title
     Search SearchCommand
   | -- | Run a query against the Zettelkasten
-    Query (Either (Some Q.Query) (Some Q.QueryGraph))
+    Query (Either (Some Q.ZettelQuery) (Some Q.GraphQuery))
   | -- | Delegate to Rib's command parser
     Rib RibConfig
 
@@ -127,13 +127,13 @@ commandParser defaultNotesDir today = do
       fmap Query $
         ( fmap
             Left
-            ( fmap (Some . flip Q.Query_ZettelByID Nothing) (option zettelIDReader (long "id"))
-                <|> fmap (\x -> Some $ Q.Query_ZettelsByTag x Nothing def) (many (mkTagPattern <$> option str (long "tag" <> short 't')))
+            ( fmap (Some . flip Q.ZettelQuery_ZettelByID Nothing) (option zettelIDReader (long "id"))
+                <|> fmap (\x -> Some $ Q.ZettelQuery_ZettelsByTag x Nothing def) (many (mkTagPattern <$> option str (long "tag" <> short 't')))
                 <|> option queryReader (long "uri" <> short 'u')
             )
             <|> fmap
               Right
-              (fmap (const $ Some $ Q.QueryGraph_Id) $ switch (long "graph" <> help "Get the entire zettelkasten graph as JSON"))
+              (fmap (const $ Some $ Q.GraphQuery_Id) $ switch (long "graph" <> help "Get the entire zettelkasten graph as JSON"))
         )
     searchCommand = do
       searchBy <-
@@ -157,7 +157,7 @@ commandParser defaultNotesDir today = do
     zettelIDReader :: ReadM ZettelID
     zettelIDReader =
       eitherReader $ first show . parseZettelID' . toText
-    queryReader :: ReadM (Some Q.Query)
+    queryReader :: ReadM (Some Q.ZettelQuery)
     queryReader =
       eitherReader $ \(toText -> s) -> case URI.mkURI s of
         Right uri ->

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -23,18 +23,17 @@ import Neuron.Zettelkasten.Zettel
 import Relude
 import System.FilePath
 
--- | Run the given query on zettels list and return the results.
-runQuery :: [Zettel] -> Query r -> r
-runQuery zs = \case
-  Query_ZettelByID zid _ ->
+runZettelQuery :: [Zettel] -> ZettelQuery r -> r
+runZettelQuery zs = \case
+  ZettelQuery_ZettelByID zid _ ->
     find ((== zid) . zettelID) zs
-  Query_ZettelsByTag pats _mconn _mview ->
+  ZettelQuery_ZettelsByTag pats _mconn _mview ->
     sortZettelsReverseChronological $ flip filter zs $ \Zettel {..} ->
       and $ flip fmap pats $ \pat ->
         any (tagMatch pat) zettelTags
-  Query_Tags [] ->
+  ZettelQuery_Tags [] ->
     allTags
-  Query_Tags pats ->
+  ZettelQuery_Tags pats ->
     Map.filterWithKey (const . tagMatchAny pats) allTags
   where
     allTags :: Map.Map Tag Natural
@@ -42,15 +41,15 @@ runQuery zs = \case
       Map.fromListWith (+) $
         concatMap (\Zettel {..} -> (,1) <$> zettelTags) zs
 
-runQueryGraph :: ZettelGraph -> QueryGraph r -> r
-runQueryGraph g = \case
-  QueryGraph_Id -> g
+runGraphQuery :: ZettelGraph -> GraphQuery r -> r
+runGraphQuery g = \case
+  GraphQuery_Id -> g
 
 queryResultJson ::
   forall r.
-  (ToJSON (Query r)) =>
+  (ToJSON (ZettelQuery r)) =>
   FilePath ->
-  Query r ->
+  ZettelQuery r ->
   r ->
   -- Zettels that cannot be parsed by neuron
   Map ZettelID Text ->
@@ -65,11 +64,11 @@ queryResultJson notesDir q r errors =
   where
     resultJson :: Value
     resultJson = case q of
-      Query_ZettelByID _ _mconn ->
+      ZettelQuery_ZettelByID _ _mconn ->
         toJSON $ zettelJsonFull <$> r
-      Query_ZettelsByTag _ _mconn _mview ->
+      ZettelQuery_ZettelsByTag _ _mconn _mview ->
         toJSON $ zettelJsonFull <$> r
-      Query_Tags _ ->
+      ZettelQuery_Tags _ ->
         toJSON $ treeToJson <$> tagTree r
     zettelJsonFull :: Zettel -> Value
     zettelJsonFull z@Zettel {..} =
@@ -84,15 +83,15 @@ queryResultJson notesDir q r errors =
           "children" .= fmap treeToJson children
         ]
 
-queryGraphResultJson ::
+graphQueryResultJson ::
   forall r.
-  (ToJSON (QueryGraph r)) =>
-  QueryGraph r ->
+  (ToJSON (GraphQuery r)) =>
+  GraphQuery r ->
   r ->
   -- Zettels that cannot be parsed by neuron (and as such are excluded from the graph)
   Map ZettelID Text ->
   Value
-queryGraphResultJson q r errors =
+graphQueryResultJson q r errors =
   toJSON $
     object
       [ "query" .= toJSON q,
@@ -102,5 +101,5 @@ queryGraphResultJson q r errors =
   where
     resultJson :: Value
     resultJson = case q of
-      QueryGraph_Id ->
+      GraphQuery_Id ->
         toJSON r

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
@@ -21,43 +21,43 @@ import Neuron.Zettelkasten.Query.Theme
 import Neuron.Zettelkasten.Zettel
 import Relude
 
--- | Query represents a way to query the zettels list.
+-- | ZettelQuery queries individual zettels.
 --
--- Note that you can only query the individual zettels, and not the graph itself
--- (which needs evaluating queries before building itself).
-data Query r where
-  Query_ZettelByID :: ZettelID -> Maybe Connection -> Query (Maybe Zettel)
-  Query_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> Query [Zettel]
-  Query_Tags :: [TagPattern] -> Query (Map Tag Natural)
+-- It does not care about the relationship *between* those zettels; for that use `GraphQuery`.
+data ZettelQuery r where
+  ZettelQuery_ZettelByID :: ZettelID -> Maybe Connection -> ZettelQuery (Maybe Zettel)
+  ZettelQuery_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> ZettelQuery [Zettel]
+  ZettelQuery_Tags :: [TagPattern] -> ZettelQuery (Map Tag Natural)
 
--- | Like `Query` but queries the zettelkasten graph instead
-data QueryGraph r where
-  QueryGraph_Id :: QueryGraph ZettelGraph
+-- | Like `GraphQuery` but focused on the relationship between zettels.
+data GraphQuery r where
+  -- | Query the entire graph.
+  GraphQuery_Id :: GraphQuery ZettelGraph
 
-deriveJSONGADT ''Query
+deriveJSONGADT ''ZettelQuery
 
-deriveGEq ''Query
+deriveGEq ''ZettelQuery
 
-deriveGShow ''Query
+deriveGShow ''ZettelQuery
 
-deriving instance Show (Query (Maybe Zettel))
+deriving instance Show (ZettelQuery (Maybe Zettel))
 
-deriving instance Show (Query [Zettel])
+deriving instance Show (ZettelQuery [Zettel])
 
-deriving instance Show (Query (Map Tag Natural))
+deriving instance Show (ZettelQuery (Map Tag Natural))
 
-deriving instance Eq (Query (Maybe Zettel))
+deriving instance Eq (ZettelQuery (Maybe Zettel))
 
-deriving instance Eq (Query [Zettel])
+deriving instance Eq (ZettelQuery [Zettel])
 
-deriving instance Eq (Query (Map Tag Natural))
+deriving instance Eq (ZettelQuery (Map Tag Natural))
 
-deriveJSONGADT ''QueryGraph
+deriveJSONGADT ''GraphQuery
 
-deriveGEq ''QueryGraph
+deriveGEq ''GraphQuery
 
-deriveGShow ''QueryGraph
+deriveGShow ''GraphQuery
 
-deriving instance Show (QueryGraph ZettelGraph)
+deriving instance Show (GraphQuery ZettelGraph)
 
-deriving instance Eq (QueryGraph ZettelGraph)
+deriving instance Eq (GraphQuery ZettelGraph)

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
@@ -15,6 +15,7 @@ import Data.GADT.Compare.TH
 import Data.GADT.Show.TH
 import Data.TagTree (Tag, TagPattern (..))
 import Neuron.Zettelkasten.Connection
+import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Theme
 import Neuron.Zettelkasten.Zettel
@@ -28,6 +29,10 @@ data Query r where
   Query_ZettelByID :: ZettelID -> Maybe Connection -> Query (Maybe Zettel)
   Query_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> Query [Zettel]
   Query_Tags :: [TagPattern] -> Query (Map Tag Natural)
+
+-- | Like `Query` but queries the zettelkasten graph instead
+data QueryGraph r where
+  QueryGraph_Id :: QueryGraph ZettelGraph
 
 deriveJSONGADT ''Query
 
@@ -46,3 +51,13 @@ deriving instance Eq (Query (Maybe Zettel))
 deriving instance Eq (Query [Zettel])
 
 deriving instance Eq (Query (Map Tag Natural))
+
+deriveJSONGADT ''QueryGraph
+
+deriveGEq ''QueryGraph
+
+deriveGShow ''QueryGraph
+
+deriving instance Show (QueryGraph ZettelGraph)
+
+deriving instance Eq (QueryGraph ZettelGraph)

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -31,7 +31,7 @@ legacyLinks = do
     for_ [("zquery", Nothing), ("zcfquery", Just OrdinaryConnection)] $ \(scheme, mconn) -> do
       context scheme $ do
         let zettelsByTag pat mview =
-              Right $ Just $ Some $ Query_ZettelsByTag (fmap mkTagPattern pat) mconn mview
+              Right $ Just $ Some $ ZettelQuery_ZettelsByTag (fmap mkTagPattern pat) mconn mview
             withScheme s = toText scheme <> s
             legacyLink l = mkURILink "." l
         it "Parse all zettels URI" $ do
@@ -59,17 +59,17 @@ legacyLinks = do
     let zid = parseZettelID "1234567"
     it "parses z:/" $
       queryFromURILink (mkURILink "1234567" "z:/")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID zid Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid Nothing)
     it "parses z:/ ignoring annotation" $
       queryFromURILink (mkURILink "1234567" "z://foo-bar")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID zid Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid Nothing)
     it "parses zcf:/" $
       queryFromURILink (mkURILink "1234567" "zcf:/")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID zid (Just OrdinaryConnection))
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid (Just OrdinaryConnection))
   describe "Parse tags URI" $ do
     it "parses zquery://tags" $
       queryFromURILink (mkURILink "." "zquery://tags?filter=foo/**")
-        `shouldBe` Right (Just $ Some $ Query_Tags [mkTagPattern "foo/**"])
+        `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo/**"])
 
 shortLinks :: Spec
 shortLinks = do
@@ -77,28 +77,28 @@ shortLinks = do
     let shortLink s = mkURILink s s
     it "parses date ID" $ do
       queryFromURILink (shortLink "1234567")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID (parseZettelID "1234567") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "1234567") Nothing)
     it "parses custom/hash ID" $ do
       queryFromURILink (shortLink "foo-bar")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID (parseZettelID "foo-bar") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Nothing)
     it "even with ?cf" $ do
       queryFromURILink (shortLink "foo-bar?cf")
-        `shouldBe` Right (Just $ Some $ Query_ZettelByID (parseZettelID "foo-bar") (Just OrdinaryConnection))
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") (Just OrdinaryConnection))
     it "z:zettels" $ do
       queryFromURILink (shortLink "z:zettels")
-        `shouldBe` Right (Just $ Some $ Query_ZettelsByTag [] Nothing def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] Nothing def)
     it "z:zettels?tag=foo" $ do
       queryFromURILink (shortLink "z:zettels?tag=foo")
-        `shouldBe` Right (Just $ Some $ Query_ZettelsByTag [mkTagPattern "foo"] Nothing def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [mkTagPattern "foo"] Nothing def)
     it "z:zettels?cf" $ do
       queryFromURILink (shortLink "z:zettels?cf")
-        `shouldBe` Right (Just $ Some $ Query_ZettelsByTag [] (Just OrdinaryConnection) def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] (Just OrdinaryConnection) def)
     it "z:tags" $ do
       queryFromURILink (shortLink "z:tags")
-        `shouldBe` Right (Just $ Some $ Query_Tags [])
+        `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [])
     it "z:tags?filter=foo" $ do
       queryFromURILink (shortLink "z:tags?filter=foo")
-        `shouldBe` Right (Just $ Some $ Query_Tags [mkTagPattern "foo"])
+        `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo"])
 
 mkURILink :: Text -> Text -> URILink
 mkURILink s l =


### PR DESCRIPTION
Exports the entire graph as JSON. Includes everything but the zettel content text.

This query cannot be used in zettel linking. In neuron there are now two kinds of queries -- one runs against a list of zettel files, and affects the graph; the other (added in this PR) operates on the built graph itself, and thus cannot be used in zettels.