### PR TITLE
Patchable graph

### DIFF
--- a/dep/dependent-sum-aeson-orphans/default.nix
+++ b/dep/dependent-sum-aeson-orphans/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/dependent-sum-aeson-orphans/github.json
+++ b/dep/dependent-sum-aeson-orphans/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "dependent-sum-aeson-orphans",
+  "branch": "develop",
+  "private": false,
+  "rev": "2ecedaf6420cafeb58b2081454aa61c4aa46e058",
+  "sha256": "0kfqx83nl70q8v7cz20qq84wxg158z674lbl4m2ga86z9lbc3jpf"
+}

--- a/dep/dependent-sum-aeson-orphans/thunk.nix
+++ b/dep/dependent-sum-aeson-orphans/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json

--- a/guide/2014401.md
+++ b/guide/2014401.md
@@ -2,9 +2,8 @@
 title: MMark Limitations
 ---
 
+{.ui .warning .message}
 **NOTE**: This page only applies to neuron version 0.4 or below, which used the mmark Markdown parser. Beginning from neuron version 0.5, however, Pandoc (via commonmark-hs) is used to represent Markdown, where these limitations do not apply. This page is left here for legacy reference. See [issue #137](https://github.com/srid/neuron/issues/137) for details.
-
----
 
 Zettel Markdown format is limited in a few ways owing to the strict parsing nature of `mmark`, the parser library used by neuron. 
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -80,7 +80,7 @@ library
     Neuron.Zettelkasten.Zettel.Parser
     Neuron.Zettelkasten.Connection
     Neuron.Zettelkasten.Query
-    Neuron.Zettelkasten.Query.Type
+    Neuron.Zettelkasten.Query.Graph
     Neuron.Zettelkasten.Query.Error
     Neuron.Zettelkasten.Query.Error.Internal
     Neuron.Zettelkasten.Query.Eval

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -77,6 +77,7 @@ library
     Neuron.Zettelkasten.ID
     Neuron.Zettelkasten.Zettel
     Neuron.Zettelkasten.Zettel.Meta
+    Neuron.Zettelkasten.Zettel.Parser
     Neuron.Zettelkasten.Connection
     Neuron.Zettelkasten.Query
     Neuron.Zettelkasten.Query.Type

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -61,6 +61,7 @@ common library-common
     aeson-gadt-th,
     dependent-sum,
     dependent-sum-template,
+    dependent-sum-aeson-orphans,
     data-default,
     reflex,
     reflex-dom-core,

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -27,6 +27,7 @@ import Neuron.Zettelkasten.ID.Scheme (IDScheme (..))
 import qualified Neuron.Zettelkasten.Query.Error as Q
 import qualified Neuron.Zettelkasten.Query.Parser as Q
 import Neuron.Zettelkasten.Query.Type as Q
+import Neuron.Zettelkasten.Zettel as Q
 import Neuron.Zettelkasten.Zettel.Meta (zettelDateFormat)
 import Options.Applicative
 import Relude

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -25,8 +25,8 @@ import Data.Time
 import Neuron.Zettelkasten.ID (ZettelID, parseZettelID')
 import Neuron.Zettelkasten.ID.Scheme (IDScheme (..))
 import qualified Neuron.Zettelkasten.Query.Error as Q
+import Neuron.Zettelkasten.Query.Graph as Q
 import qualified Neuron.Zettelkasten.Query.Parser as Q
-import Neuron.Zettelkasten.Query.Type as Q
 import Neuron.Zettelkasten.Zettel as Q
 import Neuron.Zettelkasten.Zettel.Meta (zettelDateFormat)
 import Options.Applicative

--- a/neuron/src/app/Neuron/Web/Generate.hs
+++ b/neuron/src/app/Neuron/Web/Generate.hs
@@ -113,5 +113,5 @@ loadZettelkastenFrom files = do
     s <- toText <$> readFile' path
     pure (path, s)
   let (zs, errorsSkipped) = parseZettels filesWithContent
-      g = fst $ G.mkZettelGraph zs
+      g = fst $ G.mkZettelGraph $ fmap (fst . unPandocZettel) zs
   pure (g, zs, errorsSkipped)

--- a/neuron/src/app/Neuron/Web/Generate.hs
+++ b/neuron/src/app/Neuron/Web/Generate.hs
@@ -28,6 +28,7 @@ import Neuron.Zettelkasten.Graph.Type (ZettelGraph)
 import Neuron.Zettelkasten.ID (ZettelID)
 import Neuron.Zettelkasten.Query.Error (showQueryError)
 import Neuron.Zettelkasten.Zettel
+import Neuron.Zettelkasten.Zettel.Parser
 import Options.Applicative
 import Relude
 import qualified Rib

--- a/neuron/src/lib/Data/TagTree.hs
+++ b/neuron/src/lib/Data/TagTree.hs
@@ -42,7 +42,7 @@ newtype Tag = Tag {unTag :: Text}
 --
 -- Eg.: "foo/**" matches both "foo/bar/baz" and "foo/baz"
 newtype TagPattern = TagPattern {unTagPattern :: FilePattern}
-  deriving (Eq, Show, ToJSON)
+  deriving (Eq, Show, ToJSON, FromJSON)
 
 mkTagPattern :: Text -> TagPattern
 mkTagPattern =

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -31,7 +31,6 @@ import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
 import Neuron.Zettelkasten.Query.Theme (LinkView (..), ZettelsView (..))
-import Neuron.Zettelkasten.Query.Type
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core hiding (count, tag)
 import Relude

--- a/neuron/src/lib/Neuron/Web/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/View.hs
@@ -90,7 +90,7 @@ evalAndRenderZettelQuery ::
   URILink ->
   m [QueryError]
 evalAndRenderZettelQuery graph oldRender uriLink = do
-  case flip runReaderT (G.getZettels graph) (Q.evalQueryLink uriLink) of
+  case flip runReaderT (G.getZettels graph) (Q.runQueryURILink uriLink) of
     Left (Left -> e) -> do
       -- Error parsing the query.
       fmap (e :) oldRender <* elInlineError e

--- a/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
@@ -5,7 +5,7 @@
 
 module Neuron.Zettelkasten.Connection where
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default
 import Relude hiding (show)
 import Text.Show
@@ -17,7 +17,7 @@ data Connection
     Folgezettel
   | -- | Any other ordinary connection (eg: "See also")
     OrdinaryConnection
-  deriving (Eq, Ord, Enum, Bounded, Generic, ToJSON)
+  deriving (Eq, Ord, Enum, Bounded, Generic, ToJSON, FromJSON)
 
 instance Semigroup Connection where
   -- A folgezettel link trumps all other kinds in that zettel.

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
@@ -8,7 +8,6 @@ module Neuron.Zettelkasten.Graph.Build where
 import Control.Monad.Writer (runWriterT)
 import qualified Data.Graph.Labelled as G
 import qualified Data.Map.Strict as Map
-import Data.Traversable (for)
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
@@ -16,6 +15,7 @@ import Neuron.Zettelkasten.Query.Error (QueryParseError)
 import Neuron.Zettelkasten.Query.Eval (queryConnections)
 import Neuron.Zettelkasten.Zettel
 import Relude
+import Text.Pandoc.Definition (Pandoc)
 
 -- | Build the Zettelkasten graph from a list of zettels
 --
@@ -26,18 +26,28 @@ mkZettelGraph ::
   ( ZettelGraph,
     Map ZettelID [QueryParseError]
   )
-mkZettelGraph zettels =
-  let res :: [(Zettel, ([(Maybe Connection, Zettel)], [QueryParseError]))] =
-        flip runReader (fmap (fst . unPandocZettel) zettels) $ do
-          for zettels $ \(PandocZettel (z, body)) -> fmap (z,) $ do
-            runWriterT $ queryConnections body
-      g :: ZettelGraph = G.mkGraphFrom (fst <$> res) $ flip concatMap res $ \(z1, fst -> conns) ->
-        conns <&> \(c, z2) -> (connectionMonoid (fromMaybe Folgezettel c), z1, z2)
-   in ( g,
-        Map.fromList $ flip mapMaybe res $ \(z, (_conns, errs)) ->
-          if null errs
-            then Nothing
-            else Just (zettelID z, errs)
-      )
+mkZettelGraph pZettels =
+  let zettels = fmap (fst . unPandocZettel) pZettels
+      res :: [(Zettel, ([(Maybe Connection, Zettel)], [QueryParseError]))] =
+        flip fmap pZettels $ \(PandocZettel (z, doc)) ->
+          (z, runQueryConnections zettels doc)
+      g :: ZettelGraph = G.mkGraphFrom zettels $ flip concatMap res $ \(z1, fst -> conns) ->
+        edgeFromConnection z1 <$> conns
+      errors = Map.fromList $ flip mapMaybe res $ \(z, (snd -> errs)) ->
+        if null errs
+          then Nothing
+          else Just (zettelID z, errs)
+   in (g, errors)
+
+runQueryConnections :: [Zettel] -> Pandoc -> ([(Maybe Connection, Zettel)], [QueryParseError])
+runQueryConnections zettels doc =
+  flip runReader zettels $ do
+    runWriterT $ queryConnections doc
+
+edgeFromConnection :: Zettel -> (Maybe Connection, Zettel) -> (Maybe Connection, Zettel, Zettel)
+edgeFromConnection z (c, z2) =
+  (connectionMonoid $ fromMaybe Folgezettel c, z, z2)
   where
+    -- Our connection monoid will never be Nothing (mempty); see the note in
+    -- type `ZettelGraph`.
     connectionMonoid = Just

--- a/neuron/src/lib/Neuron/Zettelkasten/ID.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/ID.hs
@@ -53,6 +53,12 @@ instance FromJSON ZettelID where
 instance ToJSONKey ZettelID where
   toJSONKey = toJSONKeyText zettelIDText
 
+instance FromJSONKey ZettelID where
+  fromJSONKey = FromJSONKeyTextParser $ \s ->
+    case parseZettelID' s of
+      Right v -> pure v
+      Left e -> fail $ show e
+
 instance ToJSON ZettelID where
   toJSON = toJSON . zettelIDText
 

--- a/neuron/src/lib/Neuron/Zettelkasten/ID.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/ID.hs
@@ -83,7 +83,7 @@ zettelIDSourceFileName zid = toString $ zettelIDText zid <> ".md"
 ---------
 
 data InvalidID = InvalidIDParseError Text
-  deriving (Eq, Generic, ToJSON)
+  deriving (Eq, Generic, ToJSON, FromJSON)
 
 parseZettelID :: HasCallStack => Text -> ZettelID
 parseZettelID =

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -18,7 +18,7 @@ import Data.TagTree (Tag, tagMatch, tagMatchAny, tagTree)
 import Data.Tree (Tree (..))
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Type
+import Neuron.Zettelkasten.Query.Graph
 import Neuron.Zettelkasten.Zettel
 import Relude
 import System.FilePath

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Error.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Error.hs
@@ -18,11 +18,11 @@ type QueryError = Either QueryParseError QueryResultError
 data QueryParseError
   = QueryParseError_InvalidID URI InvalidID
   | QueryParseError_UnsupportedHost URI
-  deriving (Eq, Show, Generic, ToJSON)
+  deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 -- | This error is only thrown when *using* (eg: in HTML) the query results.
 data QueryResultError = QueryResultError_NoSuchZettel ZettelID
-  deriving (Eq, Show, Generic, ToJSON)
+  deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
 queryParseErrorUri :: QueryParseError -> URI
 queryParseErrorUri = \case

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Error/Internal.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Error/Internal.hs
@@ -7,7 +7,10 @@ module Neuron.Zettelkasten.Query.Error.Internal where
 
 import Data.Aeson
 import Relude
-import Text.URI (URI, render)
+import Text.URI (URI, mkURI, render)
 
 instance ToJSON URI where
   toJSON = toJSON @Text . render
+
+instance FromJSON URI where
+  parseJSON = (either (fail . displayException) pure) . mkURI <=< parseJSON @Text

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
@@ -18,7 +18,6 @@ import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Query (runZettelQuery)
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Parser (queryFromURILink)
-import Neuron.Zettelkasten.Query.Type
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Pandoc.URILink (URILink, queryURILinks)
 import Relude

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Graph.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Graph.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Neuron.Zettelkasten.Query.Type where
+module Neuron.Zettelkasten.Query.Graph where
 
 import Data.Aeson
 import Data.Aeson.GADT.TH

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -14,7 +14,6 @@
 module Neuron.Zettelkasten.Query.Parser where
 
 import Control.Monad.Except
-import Control.Monad.Writer
 import Data.Some
 import Data.TagTree (mkTagPattern)
 import Neuron.Zettelkasten.Connection
@@ -23,24 +22,10 @@ import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
 import Neuron.Zettelkasten.Zettel (ZettelQuery (..))
 import Reflex.Dom.Pandoc (URILink (..))
-import Reflex.Dom.Pandoc.URILink (queryURILinks)
 import Relude
-import Text.Pandoc.Definition (Pandoc (..))
 import qualified Text.URI as URI
 import Text.URI.QQ (queryKey)
 import Text.URI.Util (getQueryParam, hasQueryFlag)
-
--- | Extract all (valid) queries from the Pandoc document
--- TODO: Use this function in Eval.hs
-extractQueries :: MonadWriter [QueryParseError] m => Pandoc -> m [Some ZettelQuery]
-extractQueries doc =
-  fmap catMaybes $ forM (queryURILinks doc) $ \ul ->
-    case queryFromURILink ul of
-      Left e -> do
-        tell [e]
-        pure Nothing
-      Right v ->
-        pure v
 
 -- | Parse a query from the given URI.
 --

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -14,6 +14,7 @@
 module Neuron.Zettelkasten.Query.Parser where
 
 import Control.Monad.Except
+import Control.Monad.Writer
 import Data.Some
 import Data.TagTree (mkTagPattern)
 import Neuron.Zettelkasten.Connection
@@ -22,10 +23,24 @@ import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
 import Neuron.Zettelkasten.Zettel (ZettelQuery (..))
 import Reflex.Dom.Pandoc (URILink (..))
+import Reflex.Dom.Pandoc.URILink (queryURILinks)
 import Relude
+import Text.Pandoc.Definition (Pandoc (..))
 import qualified Text.URI as URI
 import Text.URI.QQ (queryKey)
 import Text.URI.Util (getQueryParam, hasQueryFlag)
+
+-- | Extract all (valid) queries from the Pandoc document
+-- TODO: Use this function in Eval.hs
+extractQueries :: MonadWriter [QueryParseError] m => Pandoc -> m [Some ZettelQuery]
+extractQueries doc =
+  fmap catMaybes $ forM (queryURILinks doc) $ \ul ->
+    case queryFromURILink ul of
+      Left e -> do
+        tell [e]
+        pure Nothing
+      Right v ->
+        pure v
 
 -- | Parse a query from the given URI.
 --

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -20,7 +20,7 @@ import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
-import Neuron.Zettelkasten.Query.Type (ZettelQuery (..))
+import Neuron.Zettelkasten.Zettel (ZettelQuery (..))
 import Reflex.Dom.Pandoc (URILink (..))
 import Relude
 import qualified Text.URI as URI

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Theme.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Theme.hs
@@ -7,7 +7,7 @@
 
 module Neuron.Zettelkasten.Query.Theme where
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default
 import Relude
 
@@ -15,14 +15,14 @@ data ZettelsView = ZettelsView
   { zettelsViewLinkView :: LinkView,
     zettelsViewGroupByTag :: Bool
   }
-  deriving (Eq, Show, Ord, Generic, ToJSON)
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
 
 type ZettelView = LinkView
 
 data LinkView = LinkView
   { linkViewShowDate :: Bool
   }
-  deriving (Eq, Show, Ord, Generic, ToJSON)
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
 
 instance Default LinkView where
   def = LinkView False

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Type.hs
@@ -11,46 +11,16 @@ module Neuron.Zettelkasten.Query.Type where
 
 import Data.Aeson
 import Data.Aeson.GADT.TH
+import Data.Dependent.Sum.Orphans ()
 import Data.GADT.Compare.TH
 import Data.GADT.Show.TH
-import Data.TagTree (Tag, TagPattern (..))
-import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph.Type
-import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Theme
-import Neuron.Zettelkasten.Zettel
 import Relude
-
--- | ZettelQuery queries individual zettels.
---
--- It does not care about the relationship *between* those zettels; for that use `GraphQuery`.
-data ZettelQuery r where
-  ZettelQuery_ZettelByID :: ZettelID -> Maybe Connection -> ZettelQuery (Maybe Zettel)
-  ZettelQuery_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> ZettelQuery [Zettel]
-  ZettelQuery_Tags :: [TagPattern] -> ZettelQuery (Map Tag Natural)
 
 -- | Like `GraphQuery` but focused on the relationship between zettels.
 data GraphQuery r where
   -- | Query the entire graph.
   GraphQuery_Id :: GraphQuery ZettelGraph
-
-deriveJSONGADT ''ZettelQuery
-
-deriveGEq ''ZettelQuery
-
-deriveGShow ''ZettelQuery
-
-deriving instance Show (ZettelQuery (Maybe Zettel))
-
-deriving instance Show (ZettelQuery [Zettel])
-
-deriving instance Show (ZettelQuery (Map Tag Natural))
-
-deriving instance Eq (ZettelQuery (Maybe Zettel))
-
-deriving instance Eq (ZettelQuery [Zettel])
-
-deriving instance Eq (ZettelQuery (Map Tag Natural))
 
 deriveJSONGADT ''GraphQuery
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -75,7 +75,8 @@ sortZettelsReverseChronological :: [Zettel] -> [Zettel]
 sortZettelsReverseChronological =
   sortOn (Down . zettelDay)
 
--- TODO: Huh, we already have ToJSON instances. What is this for?
+-- TODO: Remove this in favour of the ToJSON instance (which now includes queries).
+-- That will affect the `neuron query` output, as well neuron-mode.
 zettelJson :: forall a. KeyValue a => Zettel -> [a]
 zettelJson Zettel {..} =
   [ "id" .= toJSON zettelID,

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -28,6 +28,7 @@ import Data.TagTree (TagPattern (..))
 import Data.Time.Calendar
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
+import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
 import Relude hiding (show)
 import Text.Pandoc.Definition (Pandoc (..))
@@ -49,7 +50,7 @@ data Zettel = Zettel
     zettelTitle :: Text,
     zettelTags :: [Tag],
     zettelDay :: Maybe Day,
-    zettelQueries :: [Some ZettelQuery]
+    zettelQueries :: ([Some ZettelQuery], [QueryParseError])
   }
   deriving (Generic)
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
@@ -30,9 +30,8 @@ parseZettel zid s = do
         -- creation date in the ID.
         ZettelDateID v _ -> Just v
         ZettelCustomID _ -> Meta.date =<< meta
-      -- We ignore errors here, as they will be dealt with during rendering stage.
-      (queries, _errors) = runWriter (extractQueries doc)
-  pure $ PandocZettel (Zettel zid title tags day queries, doc)
+      (queries, errors) = runWriter (extractQueries doc)
+  pure $ PandocZettel (Zettel zid title tags day (queries, errors), doc)
 
 -- | Like `parseZettel` but operates on multiple files.
 parseZettels ::

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -6,13 +7,17 @@ module Neuron.Zettelkasten.Zettel.Parser where
 
 import Control.Monad.Writer
 import qualified Data.Map.Strict as Map
+import Data.Some
 import Neuron.Markdown
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Parser
+import Neuron.Zettelkasten.Query.Error
+import Neuron.Zettelkasten.Query.Parser (queryFromURILink)
 import Neuron.Zettelkasten.Zettel
 import qualified Neuron.Zettelkasten.Zettel.Meta as Meta
 import Reflex.Class (filterLeft, filterRight)
+import Reflex.Dom.Pandoc.URILink (queryURILinks)
 import Relude
+import Text.Pandoc.Definition (Pandoc)
 
 -- | Parse a markdown-formatted zettel
 --
@@ -30,8 +35,19 @@ parseZettel zid s = do
         -- creation date in the ID.
         ZettelDateID v _ -> Just v
         ZettelCustomID _ -> Meta.date =<< meta
-      (queries, errors) = runWriter (extractQueries doc)
+      (queries, errors) = runWriter $ extractQueries doc
   pure $ PandocZettel (Zettel zid title tags day (queries, errors), doc)
+  where
+    -- Extract all (valid) queries from the Pandoc document
+    extractQueries :: MonadWriter [QueryParseError] m => Pandoc -> m [Some ZettelQuery]
+    extractQueries doc =
+      fmap catMaybes $ forM (queryURILinks doc) $ \ul ->
+        case queryFromURILink ul of
+          Left e -> do
+            tell [e]
+            pure Nothing
+          Right v ->
+            pure v
 
 -- | Like `parseZettel` but operates on multiple files.
 parseZettels ::

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Neuron.Zettelkasten.Zettel.Parser where
+
+import Control.Monad.Writer
+import qualified Data.Map.Strict as Map
+import Neuron.Markdown
+import Neuron.Zettelkasten.ID
+import Neuron.Zettelkasten.Query.Parser
+import Neuron.Zettelkasten.Zettel
+import qualified Neuron.Zettelkasten.Zettel.Meta as Meta
+import Reflex.Class (filterLeft, filterRight)
+import Relude
+
+-- | Parse a markdown-formatted zettel
+--
+-- In future this will support other formats supported by Pandoc.
+parseZettel ::
+  ZettelID ->
+  Text ->
+  Either Text PandocZettel
+parseZettel zid s = do
+  (meta, doc) <- parseMarkdown (zettelIDSourceFileName zid) s
+  let title = maybe "Missing title" Meta.title meta
+      tags = fromMaybe [] $ Meta.tags =<< meta
+      day = case zid of
+        -- We ignore the "data" meta field on legacy Date IDs, which encode the
+        -- creation date in the ID.
+        ZettelDateID v _ -> Just v
+        ZettelCustomID _ -> Meta.date =<< meta
+      -- We ignore errors here, as they will be dealt with during rendering stage.
+      (queries, _errors) = runWriter (extractQueries doc)
+  pure $ PandocZettel (Zettel zid title tags day queries, doc)
+
+-- | Like `parseZettel` but operates on multiple files.
+parseZettels ::
+  [(FilePath, Text)] ->
+  ( [PandocZettel],
+    -- List of zettel files that cannot be parsed.
+    Map ZettelID Text
+  )
+parseZettels fs =
+  let res = flip mapMaybe fs $ \(f, s) ->
+        case getZettelID f of
+          Nothing -> Nothing
+          Just zid ->
+            Just $ first (zid,) $ parseZettel zid s
+      errors = filterLeft res
+      zs = filterRight res
+   in (zs, Map.fromList errors)

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -14,7 +14,7 @@ import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Parser
 import Neuron.Zettelkasten.Query.Theme
-import Neuron.Zettelkasten.Query.Type
+import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Pandoc.URILink
 import Relude
 import Test.Hspec

--- a/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
@@ -22,8 +22,9 @@ spec = do
   describe "sortZettelsReverseChronological" $ do
     let mkDay = fromGregorian 2020 3
         (_ :: Meta, _dummyContent) = either error id $ parseMarkdown "<spec>" "Dummy"
+        noQueries = (mempty, mempty) -- TODO: test queries
         mkZettel day idx =
-          Zettel (ZettelDateID (mkDay day) idx) "Some title" [Tag "science", Tag "journal/class"] (Just $ mkDay day)
+          Zettel (ZettelDateID (mkDay day) idx) "Some title" [Tag "science", Tag "journal/class"] (Just $ mkDay day) noQueries
     it "sorts correctly" $ do
       let zs = [mkZettel 3 2, mkZettel 5 1]
       sortZettelsReverseChronological zs
@@ -31,8 +32,9 @@ spec = do
   describe "Zettel JSON" $ do
     let day = fromGregorian 2020 3 19
         zid = ZettelCustomID "Foo-Bar"
+        noQueries = (mempty, mempty) -- TODO: test queries
         (_ :: Meta, _dummyContent) = either error id $ parseMarkdown "<spec>" "Dummy"
-        zettel = Zettel zid "Some title" [Tag "science", Tag "journal/class"] (Just day)
+        zettel = Zettel zid "Some title" [Tag "science", Tag "journal/class"] (Just day) noQueries
     it "Produces expected json" $ do
       -- "{\"id\":\"2011401\",\"title\":\"Some title\",\"tags\":[\"science\"]}"
       object (zettelJson zettel)

--- a/project.nix
+++ b/project.nix
@@ -37,6 +37,7 @@ in {
 
     reflex-dom-pandoc = hackGet ./dep/reflex-dom-pandoc;
     shake = hackGet ./dep/shake;
+    dependent-sum-aeson-orphans = hackGet ./dep/dependent-sum-aeson-orphans;
     
     # commonmark
     commonmark = commonmark + "/commonmark";


### PR DESCRIPTION
Include zettel queries in the zettel metadata (they will also appear in `neuron query --graph` JSON) such that a graph can be patched (with modified/new/deleted zettels) without depending on the original zettel text or Pandoc documents.