### PR TITLE
Propagate query result errors to the graph

### DIFF
--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.5.3.0
+version: 0.5.4.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Web.Query.View
-  ( renderQueryResultIfSuccessful,
+  ( renderQueryResult,
     renderZettelLink,
     zettelUrl,
     tagUrl,
@@ -34,26 +34,17 @@ import qualified Neuron.Web.Theme as Theme
 import Neuron.Web.Widget
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
 import Neuron.Zettelkasten.Query.Theme (LinkView (..), ZettelsView (..))
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core hiding (count, tag)
 import Relude
 
 -- | Render the query results.
---
--- If the query result is unexpected, don't render anything and return
--- `QueryResultError` which the caller is expected to handle.
-renderQueryResultIfSuccessful ::
-  DomBuilder t m => DSum ZettelQuery Identity -> NeuronWebT t m (Maybe QueryResultError)
-renderQueryResultIfSuccessful = \case
-  ZettelQuery_ZettelByID zid (fromMaybe def -> conn) :=> Identity mres ->
-    case mres of
-      Nothing ->
-        pure $ Just $ QueryResultError_NoSuchZettel zid
-      Just target -> do
-        renderZettelLink (Just conn) Nothing target
-        pure Nothing
+renderQueryResult ::
+  DomBuilder t m => DSum ZettelQuery Identity -> NeuronWebT t m ()
+renderQueryResult = \case
+  ZettelQuery_ZettelByID _zid (fromMaybe def -> conn) :=> Identity target -> do
+    renderZettelLink (Just conn) Nothing target
   q@(ZettelQuery_ZettelsByTag pats (fromMaybe def -> conn) view) :=> Identity res -> do
     el "section" $ do
       renderQuery $ Some q
@@ -71,12 +62,10 @@ renderQueryResultIfSuccessful = \case
               el "ul" $ forM_ zettelGrp $ \z ->
                 el "li" $
                   renderZettelLink (Just conn) (Just $ zettelsViewLinkView view) z
-    pure Nothing
   q@(ZettelQuery_Tags _) :=> Identity res -> do
     el "section" $ do
       renderQuery $ Some q
       renderTagTree $ foldTagTree $ tagTree res
-    pure Nothing
   where
     -- TODO: Instead of doing this here, group the results in runQuery itself.
     groupZettelsByTagsMatching pats matches =

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -13,6 +13,7 @@
 module Neuron.Web.Query.View
   ( renderQueryResult,
     renderZettelLink,
+    renderZettelLinkIDOnly,
     zettelUrl,
     tagUrl,
     style,
@@ -122,6 +123,13 @@ renderZettelLink conn (fromMaybe def -> LinkView {..}) Zettel {..} = do
             <> "data-inverted" =: ""
             <> "data-position" =: "right center"
         )
+
+-- | Like `renderZettelLink` but when we only have ID in hand.
+renderZettelLinkIDOnly :: DomBuilder t m => ZettelID -> NeuronWebT t m ()
+renderZettelLinkIDOnly zid =
+  elClass "span" "zettel-link-container" $ do
+    elClass "span" "zettel-link" $ do
+      neuronRouteLink (Some $ Route_Zettel zid) mempty $ text $ zettelIDText zid
 
 renderTagTree :: forall t m. DomBuilder t m => Forest (NonEmpty TagNode, Natural) -> m ()
 renderTagTree t =

--- a/neuron/src/lib/Neuron/Web/ZIndex.hs
+++ b/neuron/src/lib/Neuron/Web/ZIndex.hs
@@ -59,7 +59,7 @@ renderZIndex neuronTheme graph errors = do
       1 -> "is 1 " <> noun
       n -> "are " <> show n <> " " <> nounPlural
 
-renderErrors :: DomBuilder t m => Map ZettelID (Either ZettelParseError [QueryError]) -> m ()
+renderErrors :: DomBuilder t m => Map ZettelID (Either ZettelParseError [QueryError]) -> NeuronWebT t m ()
 renderErrors errors = do
   let skippedZettels = Map.mapMaybe leftToMaybe errors
       zettelsWithErrors = Map.mapMaybe rightToMaybe errors
@@ -78,9 +78,7 @@ renderErrors errors = do
     divClass "ui tiny warning message" $ do
       divClass "header" $ do
         text $ "Zettel "
-        elClass "span" "zettel-link-container" $ do
-          elClass "span" "zettel-link" $ do
-            elAttr "a" ("href" =: QueryView.zettelUrl zid) $ text $ zettelIDText zid
+        QueryView.renderZettelLinkIDOnly zid
         text " has errors"
       el "p" $ do
         el "ol" $ do

--- a/neuron/src/lib/Neuron/Web/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/View.hs
@@ -92,20 +92,15 @@ evalAndRenderZettelQuery ::
   NeuronWebT t m [QueryError]
 evalAndRenderZettelQuery graph oldRender uriLink = do
   case flip runReaderT (G.getZettels graph) (Q.runQueryURILink uriLink) of
-    Left (Left -> e) -> do
-      -- Error parsing the query.
+    Left e -> do
+      -- Error parsing or running the query.
       fmap (e :) oldRender <* elInlineError e
     Right Nothing -> do
       -- This is not a query link; pass through.
       oldRender
     Right (Just res) -> do
-      Q.renderQueryResultIfSuccessful res >>= \case
-        Nothing ->
-          -- Successfully rendered.
-          pure mempty
-        Just (Right -> e) -> do
-          -- Error in query results.
-          fmap (e :) oldRender <* elInlineError e
+      Q.renderQueryResult res
+      pure mempty
   where
     elInlineError e =
       elClass "span" "ui left pointing red basic label" $ do

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
@@ -11,7 +11,7 @@ import qualified Data.Map.Strict as Map
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Error (QueryParseError)
+import Neuron.Zettelkasten.Query.Error (QueryError)
 import Neuron.Zettelkasten.Query.Eval (queryConnections)
 import Neuron.Zettelkasten.Zettel
 import Relude
@@ -23,10 +23,10 @@ import Relude
 mkZettelGraph ::
   [Zettel] ->
   ( ZettelGraph,
-    Map ZettelID [QueryParseError]
+    Map ZettelID [QueryError]
   )
 mkZettelGraph zettels =
-  let res :: [(Zettel, ([(Maybe Connection, Zettel)], [QueryParseError]))] =
+  let res :: [(Zettel, ([(Maybe Connection, Zettel)], [QueryError]))] =
         flip fmap zettels $ \z ->
           (z, runQueryConnections zettels z)
       g :: ZettelGraph = G.mkGraphFrom zettels $ flip concatMap res $ \(z1, fst -> conns) ->
@@ -37,7 +37,7 @@ mkZettelGraph zettels =
           else Just (zettelID z, errs)
    in (g, errors)
 
-runQueryConnections :: [Zettel] -> Zettel -> ([(Maybe Connection, Zettel)], [QueryParseError])
+runQueryConnections :: [Zettel] -> Zettel -> ([(Maybe Connection, Zettel)], [QueryError])
 runQueryConnections zettels z =
   flip runReader zettels $ do
     runWriterT $ queryConnections z

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
@@ -32,17 +32,23 @@ import Relude
 --
 -- We need the full list of zettels, for running the query against.
 runQueryURILink ::
-  ( MonadError QueryParseError m,
+  ( MonadError QueryError m,
     MonadReader [Zettel] m
   ) =>
   URILink ->
   m (Maybe (DSum ZettelQuery Identity))
-runQueryURILink =
-  traverse runSomeZettelQuery <=< queryFromURILink
+runQueryURILink ul = do
+  mq <- liftEither $ first Left $ queryFromURILink ul
+  flip traverse mq $ \q ->
+    either (throwError . Right) pure =<< runExceptT (runSomeZettelQuery q)
 
+-- Query connections in the given zettel
+--
+-- Tell all errors; query parse errors (as already stored in `Zettel`) as well
+-- query result errors.
 queryConnections ::
   ( -- Errors are written aside, accumulating valid connections.
-    MonadWriter [QueryParseError] m,
+    MonadWriter [QueryError] m,
     -- Running queries requires the zettels list.
     MonadReader [Zettel] m
   ) =>
@@ -50,25 +56,36 @@ queryConnections ::
   m [(Maybe Connection, Zettel)]
 queryConnections Zettel {..} = do
   let (queries, errors) = zettelQueries
-  tell errors
+  -- Report any query parse errors
+  tell $ Left <$> errors
   fmap concat $ forM queries $ \someQ ->
-    getConnections <$> runSomeZettelQuery someQ
+    runExceptT (runSomeZettelQuery someQ) >>= \case
+      Left e -> do
+        tell [Right e]
+        pure mempty
+      Right res ->
+        pure $ getConnections res
   where
     getConnections :: DSum ZettelQuery Identity -> [(Maybe Connection, Zettel)]
     getConnections = \case
-      ZettelQuery_ZettelByID _ mconn :=> Identity mres ->
-        maybe [] pure $ (mconn,) <$> mres
+      ZettelQuery_ZettelByID _ mconn :=> Identity res ->
+        [(mconn, res)]
       ZettelQuery_ZettelsByTag _ mconn _mview :=> Identity res ->
         (mconn,) <$> res
       ZettelQuery_Tags _ :=> _ ->
         mempty
 
 runSomeZettelQuery ::
-  MonadReader [Zettel] m =>
+  ( MonadError QueryResultError m,
+    MonadReader [Zettel] m
+  ) =>
   Some ZettelQuery ->
   m (DSum ZettelQuery Identity)
 runSomeZettelQuery someQ =
   withSome someQ $ \q -> do
     zs <- ask
-    let res = runZettelQuery zs q
-    pure $ q :=> Identity res
+    case runZettelQuery zs q of
+      Left e ->
+        throwError e
+      Right res ->
+        pure $ q :=> Identity res

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -38,7 +38,7 @@ import Text.Show (Show (show))
 --
 -- It does not care about the relationship *between* those zettels; for that use `GraphQuery`.
 data ZettelQuery r where
-  ZettelQuery_ZettelByID :: ZettelID -> Maybe Connection -> ZettelQuery (Maybe Zettel)
+  ZettelQuery_ZettelByID :: ZettelID -> Maybe Connection -> ZettelQuery Zettel
   ZettelQuery_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> ZettelQuery [Zettel]
   ZettelQuery_Tags :: [TagPattern] -> ZettelQuery (Map Tag Natural)
 

--- a/neuron/test/Neuron/VersionSpec.hs
+++ b/neuron/test/Neuron/VersionSpec.hs
@@ -28,10 +28,10 @@ spec = do
       "0.4" `isLesserOrEqual` olderThan
     it "full versions" $ do
       "0.6.1.2" `isGreater` olderThan
-      "0.5.4" `isGreater` olderThan
-      "0.5.3.8" `isGreater` olderThan
-      "0.5.3.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.5" `isGreater` olderThan
+      "0.5.4.8" `isGreater` olderThan
+      "0.5.4.0" `isLesserOrEqual` olderThan -- This is current version
       "0.3.1.0" `isLesserOrEqual` olderThan
     it "within same major version" $ do
-      "0.5.3.8" `isGreater` olderThan
-      "0.5.3.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.4.8" `isGreater` olderThan
+      "0.5.4.0" `isLesserOrEqual` olderThan -- This is current version


### PR DESCRIPTION
This affects the `neuron query` JSON slightly:

- `errors` field is renamed to `skipped` (because it contains zettels that failed to parse, hence "skipped")
- A new `error` field will be present for `--id` queries (or `--uri <id>`), if and only if the zettel ID being queried does not exist.

There should be no change to the `result` or `query` fields.