### PR TITLE
Render raw zettel on parse errors

### DIFF
--- a/neuron/src/app/Main.hs
+++ b/neuron/src/app/Main.hs
@@ -33,14 +33,14 @@ generateMainSite :: Action ()
 generateMainSite = do
   Rib.buildStaticFiles ["static/**"]
   config <- Config.getConfig
-  let writeHtmlRoute :: Route a -> (ZettelGraph, a) -> Action (RouteError a)
+  let writeHtmlRoute :: Route a -> (ZettelGraph, a) -> Action ()
       writeHtmlRoute r x = do
-        (errors, html) <- liftIO $ renderStatic $ do
+        (_res, html) <- liftIO $ renderStatic $ do
           runNeuronWeb staticRouteConfig $
             renderPage config r x
         -- FIXME: Make rib take bytestrings
         Rib.writeRoute r $ decodeUtf8 @Text html
-        pure errors
+        pure ()
   void $ generateSite config writeHtmlRoute
 
 renderPage :: PandocBuilder t m => Config -> Route a -> (ZettelGraph, a) -> NeuronWebT t m (RouteError a)

--- a/neuron/src/app/Main.hs
+++ b/neuron/src/app/Main.hs
@@ -18,7 +18,7 @@ import Neuron.Config (Config)
 import qualified Neuron.Config as Config
 import Neuron.Web.Generate (generateSite)
 import Neuron.Web.Generate.Route (staticRouteConfig)
-import Neuron.Web.Route (NeuronWebT, Route (..), RouteError, runNeuronWeb)
+import Neuron.Web.Route (NeuronWebT, Route (..), runNeuronWeb)
 import Neuron.Web.View (renderRouteBody, renderRouteHead, style)
 import Neuron.Zettelkasten.Graph.Type (ZettelGraph)
 import Reflex.Dom.Core
@@ -35,15 +35,14 @@ generateMainSite = do
   config <- Config.getConfig
   let writeHtmlRoute :: Route a -> (ZettelGraph, a) -> Action ()
       writeHtmlRoute r x = do
-        (_res, html) <- liftIO $ renderStatic $ do
+        ((), html) <- liftIO $ renderStatic $ do
           runNeuronWeb staticRouteConfig $
             renderPage config r x
         -- FIXME: Make rib take bytestrings
         Rib.writeRoute r $ decodeUtf8 @Text html
-        pure ()
   void $ generateSite config writeHtmlRoute
 
-renderPage :: PandocBuilder t m => Config -> Route a -> (ZettelGraph, a) -> NeuronWebT t m (RouteError a)
+renderPage :: PandocBuilder t m => Config -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
 renderPage config r val = elAttr "html" ("lang" =: "en") $ do
   el "head" $ do
     renderRouteHead config r val

--- a/neuron/src/app/Neuron/CLI/New.hs
+++ b/neuron/src/app/Neuron/CLI/New.hs
@@ -34,10 +34,14 @@ import System.Posix.Process
 -- As well as print the path to the created file.
 newZettelFile :: NewCommand -> Action ()
 newZettelFile NewCommand {..} = do
-  zettels <- Gen.loadZettelsIgnoringErrors
+  (_, zettels, _) <- Gen.loadZettelkasten
   mzid <- withSome idScheme $ \scheme -> do
     val <- liftIO $ IDScheme.genVal scheme
-    pure $ IDScheme.nextAvailableZettelID (Set.fromList $ fmap zettelID zettels) val scheme
+    pure $
+      IDScheme.nextAvailableZettelID
+        (Set.fromList $ fmap (either zettelID zettelID) zettels)
+        val
+        scheme
   case mzid of
     Left e -> die $ show e
     Right zid -> do

--- a/neuron/src/app/Neuron/Web/Generate.hs
+++ b/neuron/src/app/Neuron/Web/Generate.hs
@@ -28,7 +28,6 @@ import Neuron.Zettelkasten.Graph.Type (ZettelGraph)
 import Neuron.Zettelkasten.ID (ZettelID)
 import Neuron.Zettelkasten.Query.Error (showQueryError)
 import Neuron.Zettelkasten.Zettel
-import Neuron.Zettelkasten.Zettel.Parser
 import Options.Applicative
 import Relude
 import qualified Rib
@@ -108,9 +107,4 @@ loadZettelkastenFrom files = do
     need [path]
     s <- decodeUtf8With lenientDecode <$> readFileBS path
     pure (path, s)
-  let zs = parseZettels filesWithContent
-      skippedErrors = Map.fromList $ flip mapMaybe zs $ \case
-        Left (Zettel {..}) -> Just (zettelID, zettelError)
-        Right _ -> Nothing
-      (g, queryErrors) = G.mkZettelGraph $ fmap sansContent zs
-  pure (g, zs, fmap Left skippedErrors `Map.union` fmap Right queryErrors)
+  pure $ G.buildZettelkasten filesWithContent

--- a/neuron/src/app/Neuron/Web/StructuredData.hs
+++ b/neuron/src/app/Neuron/Web/StructuredData.hs
@@ -77,6 +77,8 @@ routeOpenGraph Config {..} v r =
         baseUrl <- siteBaseUrl
         pure $ routeUri baseUrl r
     }
+  where
+    getPandocDoc = either (const Nothing) (Just . zettelContent)
 
 renderOpenGraph :: forall t m. DomBuilder t m => OpenGraph -> m ()
 renderOpenGraph OpenGraph {..} = do

--- a/neuron/src/app/Neuron/Web/StructuredData.hs
+++ b/neuron/src/app/Neuron/Web/StructuredData.hs
@@ -44,7 +44,7 @@ routeStructuredData Config {..} (graph, v) = \case
         let mkCrumb :: Zettel -> Breadcrumb.Item
             mkCrumb Zettel {..} =
               Breadcrumb.Item zettelTitle (Just $ routeUri baseUrl $ Route_Zettel zettelID)
-         in Breadcrumb.fromForest $ fmap mkCrumb <$> G.backlinkForest Folgezettel (fst $ unPandocZettel v) graph
+         in Breadcrumb.fromForest $ fmap mkCrumb <$> G.backlinkForest Folgezettel (sansContent v) graph
   _ ->
     []
 
@@ -58,7 +58,7 @@ routeOpenGraph Config {..} v r =
         Route_ZIndex -> Just "Zettelkasten Index"
         Route_Search -> Just "Search Zettelkasten"
         Route_Zettel _ -> do
-          let PandocZettel (_, doc) = v
+          doc <- getPandocDoc v
           para <- getFirstParagraphText doc
           paraText <- renderPandocAsText para
           pure $ T.take 300 paraText,
@@ -68,7 +68,7 @@ routeOpenGraph Config {..} v r =
         _ -> Just OGType_Website,
       _openGraph_image = case r of
         Route_Zettel _ -> do
-          let PandocZettel (_, doc) = v
+          doc <- getPandocDoc v
           image <- URI.mkURI =<< Pandoc.getFirstImg doc
           baseUrl <- URI.mkURI =<< siteBaseUrl
           URI.relativeTo image baseUrl

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -85,7 +85,7 @@ renderRouteHead config route val = do
             then x
             else x <> " - " <> suffix
 
-renderRouteBody :: PandocBuilder t m => Config -> Route a -> (ZettelGraph, a) -> NeuronWebT t m (RouteError a)
+renderRouteBody :: PandocBuilder t m => Config -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
 renderRouteBody Config {..} r (g, x) = do
   let neuronTheme = Theme.mkTheme theme
   case r of

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -43,7 +43,7 @@ import qualified Neuron.Web.Zettel.CSS as ZettelCSS
 import qualified Neuron.Web.Zettel.View as ZettelView
 import qualified Neuron.Zettelkasten.Graph as G
 import Neuron.Zettelkasten.Graph (ZettelGraph)
-import Neuron.Zettelkasten.ID (zettelIDSourceFileName)
+import Neuron.Zettelkasten.ID (ZettelID, zettelIDSourceFileName)
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core hiding ((&))
 import Reflex.Dom.Pandoc (PandocBuilder)
@@ -102,7 +102,7 @@ renderRouteBody Config {..} r (g, x) = do
         renderBrandFooter
       pure mempty
     Route_Zettel _ -> do
-      actionsNav neuronTheme editUrl (Just $ fst $ unPandocZettel x)
+      actionsNav neuronTheme editUrl (Just $ either zettelID zettelID x)
       ZettelView.renderZettel (g, x)
         <* renderBrandFooter
     Route_Redirect _ -> do
@@ -145,13 +145,13 @@ renderBrandFooter =
 fa :: DomBuilder t m => Text -> m ()
 fa k = elClass "i" k blank
 
-actionsNav :: DomBuilder t m => Theme -> Maybe Text -> Maybe Zettel -> NeuronWebT t m ()
-actionsNav theme editUrl mzettel = elClass "nav" "top-menu" $ do
+actionsNav :: DomBuilder t m => Theme -> Maybe Text -> Maybe ZettelID -> NeuronWebT t m ()
+actionsNav theme editUrl mzid = elClass "nav" "top-menu" $ do
   divClass ("ui inverted compact neuron icon menu " <> Theme.semanticColor theme) $ do
     neuronRouteLink (Some Route_ZIndex) ("class" =: "left item" <> "title" =: "All Zettels (z-index)") $
       semanticIcon "tree"
-    whenJust ((,) <$> mzettel <*> editUrl) $ \(Zettel {..}, urlPrefix) -> do
-      let attrs = ("href" =: (urlPrefix <> toText (zettelIDSourceFileName zettelID)) <> "title" =: "Edit this Zettel")
+    whenJust ((,) <$> mzid <*> editUrl) $ \(zid, urlPrefix) -> do
+      let attrs = ("href" =: (urlPrefix <> toText (zettelIDSourceFileName zid)) <> "title" =: "Edit this Zettel")
       elAttr "a" ("class" =: "center item" <> attrs) $ do
         semanticIcon "edit"
     neuronRouteLink (Some Route_Search) ("class" =: "right item" <> "title" =: "Search Zettels") $ do

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -96,7 +96,8 @@ renderQuery someQ =
 -- | Render a link to an individual zettel.
 renderZettelLink :: DomBuilder t m => Maybe Connection -> Maybe LinkView -> Zettel -> NeuronWebT t m ()
 renderZettelLink conn (fromMaybe def -> LinkView {..}) Zettel {..} = do
-  let connClass = maybe "" show conn
+  let connClass = show <$> conn
+      rawClass = either (const $ Just "raw") (const Nothing) zettelError
       mextra =
         if linkViewShowDate
           then case zettelDay of
@@ -105,7 +106,8 @@ renderZettelLink conn (fromMaybe def -> LinkView {..}) Zettel {..} = do
             Nothing ->
               Nothing
           else Nothing
-  elClass "span" ("zettel-link-container " <> connClass) $ do
+      classes :: [Text] = catMaybes $ [Just "zettel-link-container"] <> [connClass, rawClass]
+  elClass "span" (T.intercalate " " classes) $ do
     forM_ mextra $ \extra ->
       elClass "span" "extra monoFont" $ extra
     let linkTooltip =
@@ -196,5 +198,7 @@ zettelLinkCss neuronTheme = do
   "span.zettel-link-container.folgezettel::after" ? do
     C.paddingLeft $ em 0.3
     C.content $ C.stringContent "ᛦ"
+  "span.zettel-link-container.raw" ? do
+    C.border C.solid (C.px 1) C.red
   "[data-tooltip]:after" ? do
     C.fontSize $ em 0.7

--- a/neuron/src/lib/Neuron/Web/Route.hs
+++ b/neuron/src/lib/Neuron/Web/Route.hs
@@ -10,7 +10,6 @@ module Neuron.Web.Route where
 
 import Control.Monad.Reader
 import Data.Some
-import Neuron.Markdown (ZettelParseError)
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Zettel
@@ -21,19 +20,19 @@ data Route a where
   Route_Redirect :: ZettelID -> Route ZettelID
   -- ZIndex takes a report of all errors in the zettelkasten.
   -- `Left` is skipped zettels; and Right is valid zettels with invalid query links.
-  Route_ZIndex :: Route (Map ZettelID (Either ZettelParseError [QueryError]))
+  Route_ZIndex :: Route (Map ZettelID ZettelError)
   Route_Search :: Route ()
-  Route_Zettel :: ZettelID -> Route PandocZettel
+  Route_Zettel :: ZettelID -> Route ZettelC
 
 type family RouteError r
 
-type instance RouteError (Map ZettelID (Either ZettelParseError [QueryError])) = ()
+type instance RouteError (Map ZettelID ZettelError) = ()
 
 type instance RouteError ZettelID = ()
 
 type instance RouteError () = ()
 
-type instance RouteError PandocZettel = [QueryError]
+type instance RouteError ZettelC = [QueryError]
 
 data RouteConfig t m = RouteConfig
   { -- | Whether the view is being rendered for static HTML generation
@@ -63,5 +62,4 @@ routeTitle' v = \case
   Route_ZIndex -> "Zettel Index"
   Route_Search -> "Search"
   Route_Zettel _ ->
-    let PandocZettel (z, _) = v
-     in zettelTitle z
+    either zettelTitle zettelTitle v

--- a/neuron/src/lib/Neuron/Web/Route.hs
+++ b/neuron/src/lib/Neuron/Web/Route.hs
@@ -11,7 +11,6 @@ module Neuron.Web.Route where
 import Control.Monad.Reader
 import Data.Some
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core
 import Relude
@@ -23,16 +22,6 @@ data Route a where
   Route_ZIndex :: Route (Map ZettelID ZettelError)
   Route_Search :: Route ()
   Route_Zettel :: ZettelID -> Route ZettelC
-
-type family RouteError r
-
-type instance RouteError (Map ZettelID ZettelError) = ()
-
-type instance RouteError ZettelID = ()
-
-type instance RouteError () = ()
-
-type instance RouteError ZettelC = [QueryError]
 
 data RouteConfig t m = RouteConfig
   { -- | Whether the view is being rendered for static HTML generation

--- a/neuron/src/lib/Neuron/Web/ZIndex.hs
+++ b/neuron/src/lib/Neuron/Web/ZIndex.hs
@@ -13,7 +13,6 @@ where
 import Data.Foldable (maximum)
 import qualified Data.Map.Strict as Map
 import Data.Tree
-import Neuron.Markdown (ZettelParseError)
 import qualified Neuron.Web.Query.View as QueryView
 import Neuron.Web.Route
 import qualified Neuron.Web.Theme as Theme
@@ -21,7 +20,7 @@ import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph (ZettelGraph)
 import qualified Neuron.Zettelkasten.Graph as G
 import Neuron.Zettelkasten.ID
-import Neuron.Zettelkasten.Query.Error (QueryError, showQueryError)
+import Neuron.Zettelkasten.Query.Error (showQueryError)
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core hiding ((&))
 import Relude hiding ((&))
@@ -30,7 +29,7 @@ renderZIndex ::
   DomBuilder t m =>
   Theme.Theme ->
   ZettelGraph ->
-  Map ZettelID (Either ZettelParseError [QueryError]) ->
+  Map ZettelID ZettelError ->
   NeuronWebT t m ()
 renderZIndex neuronTheme graph errors = do
   elClass "h1" "header" $ text "Zettel Index"
@@ -59,7 +58,7 @@ renderZIndex neuronTheme graph errors = do
       1 -> "is 1 " <> noun
       n -> "are " <> show n <> " " <> nounPlural
 
-renderErrors :: DomBuilder t m => Map ZettelID (Either ZettelParseError [QueryError]) -> NeuronWebT t m ()
+renderErrors :: DomBuilder t m => Map ZettelID ZettelError -> NeuronWebT t m ()
 renderErrors errors = do
   let skippedZettels = Map.mapMaybe leftToMaybe errors
       zettelsWithErrors = Map.mapMaybe rightToMaybe errors

--- a/neuron/src/lib/Neuron/Web/Zettel/CSS.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/CSS.hs
@@ -84,6 +84,8 @@ zettelContentCss neuronTheme = do
     codeStyle
     definitionListStyle
     blockquoteStyle
+  ".zettel-content.raw" ? do
+    C.backgroundColor "#ddd"
   where
     definitionListStyle = do
       C.dl ? do

--- a/neuron/src/lib/Neuron/Web/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/View.hs
@@ -126,7 +126,8 @@ renderZettelRawContent Zettel {..} = do
   divClass "ui error message" $ do
     elClass "h2" "header" $ text "Zettel failed to parse"
     el "p" $ el "pre" $ text $ show zettelError
-  el "pre" $ text $ zettelContent
+  elClass "article" "ui raised attached segment zettel-content raw" $ do
+    el "pre" $ text $ zettelContent
 
 renderTags :: DomBuilder t m => NonEmpty Tag -> m ()
 renderTags tags = do

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -16,7 +16,6 @@ import Data.Aeson
 import qualified Data.Map.Strict as Map
 import Data.TagTree (Tag, tagMatch, tagMatchAny, tagTree)
 import Data.Tree (Tree (..))
-import Neuron.Markdown (ZettelParseError)
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
@@ -58,7 +57,7 @@ zettelQueryResultJson ::
   ZettelQuery r ->
   Either QueryResultError r ->
   -- Zettels that cannot be parsed by neuron
-  Map ZettelID ZettelParseError ->
+  Map ZettelID ZettelError ->
   Value
 zettelQueryResultJson notesDir q er skippedZettels =
   toJSON $
@@ -98,7 +97,7 @@ graphQueryResultJson ::
   GraphQuery r ->
   r ->
   -- Zettels that cannot be parsed by neuron (and as such are excluded from the graph)
-  Map ZettelID ZettelParseError ->
+  Map ZettelID ZettelError ->
   Value
 graphQueryResultJson q r skippedZettels =
   toJSON $

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
@@ -55,10 +55,13 @@ queryConnections ::
   Zettel ->
   m [(Maybe Connection, Zettel)]
 queryConnections Zettel {..} = do
-  let (queries, errors) = zettelQueries
   -- Report any query parse errors
-  tell $ Left <$> errors
-  fmap concat $ forM queries $ \someQ ->
+  case zettelError of
+    Right queryParseErrors ->
+      tell $ Left <$> queryParseErrors
+    Left _ ->
+      pure ()
+  fmap concat $ forM zettelQueries $ \someQ ->
     runExceptT (runSomeZettelQuery someQ) >>= \case
       Left e -> do
         tell [Right e]

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -71,23 +71,15 @@ type ZettelC = Either (ZettelT Text) (ZettelT Pandoc)
 sansContent :: ZettelC -> Zettel
 sansContent = \case
   Left z ->
-    Zettel
-      (zettelID z)
-      (zettelTitle z)
-      (zettelTags z)
-      (zettelDay z)
-      (zettelQueries z)
-      (Left $ zettelError z)
-      (MetadataOnly ())
+    z
+      { zettelError = Left $ zettelError z,
+        zettelContent = MetadataOnly ()
+      }
   Right z ->
-    Zettel
-      (zettelID z)
-      (zettelTitle z)
-      (zettelTags z)
-      (zettelDay z)
-      (zettelQueries z)
-      (Right $ zettelError z)
-      (MetadataOnly ())
+    z
+      { zettelError = Right $ zettelError z,
+        zettelContent = MetadataOnly ()
+      }
 
 type family ContentError c
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -89,11 +89,6 @@ sansContent = \case
       (Right $ zettelError z)
       (MetadataOnly ())
 
-getPandocDoc :: ZettelC -> Maybe Pandoc
-getPandocDoc = \case
-  Left _ -> Nothing
-  Right (Zettel {..}) -> Just zettelContent
-
 type family ContentError c
 
 type instance ContentError Pandoc = [QueryParseError]
@@ -103,17 +98,6 @@ type instance ContentError Text = ZettelParseError
 type instance ContentError MetadataOnly = Either (ContentError Text) (ContentError Pandoc)
 
 type ZettelError = Either ZettelParseError (NonEmpty QueryError)
-
--- | A zettel with the associated pandoc AST
-newtype PandocZettel = PandocZettel {unPandocZettel :: (Zettel, Pandoc)}
-  deriving (Eq)
-
--- old approach:
--- Zettel with content
---
--- The content is either parsed Pandoc doc, or the raw content (when parsing has
--- failed)
-data ZwC = ZwC (Zettel, Either Text Pandoc)
 
 instance Eq (ZettelT c) where
   (==) = (==) `on` zettelID

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -26,6 +28,7 @@ import Data.Some
 import Data.TagTree (Tag)
 import Data.TagTree (TagPattern (..))
 import Data.Time.Calendar
+import Neuron.Markdown
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
@@ -42,33 +45,87 @@ data ZettelQuery r where
   ZettelQuery_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> ZettelQuery [Zettel]
   ZettelQuery_Tags :: [TagPattern] -> ZettelQuery (Map Tag Natural)
 
--- | Zettel with no associated content
+-- | A zettel note
 --
 -- The metadata could have been inferred from the content.
-data Zettel = Zettel
+data ZettelT content = Zettel
   { zettelID :: ZettelID,
     zettelTitle :: Text,
     zettelTags :: [Tag],
     zettelDay :: Maybe Day,
-    zettelQueries :: ([Some ZettelQuery], [QueryParseError])
+    zettelQueries :: [Some ZettelQuery],
+    zettelError :: ContentError content,
+    zettelContent :: content
   }
   deriving (Generic)
+
+newtype MetadataOnly = MetadataOnly ()
+  deriving (Generic, ToJSON, FromJSON)
+
+-- | without the content
+type Zettel = ZettelT MetadataOnly
+
+-- | With the content
+type ZettelC = Either (ZettelT Text) (ZettelT Pandoc)
+
+sansContent :: ZettelC -> Zettel
+sansContent = \case
+  Left z ->
+    Zettel
+      (zettelID z)
+      (zettelTitle z)
+      (zettelTags z)
+      (zettelDay z)
+      (zettelQueries z)
+      (Left $ zettelError z)
+      (MetadataOnly ())
+  Right z ->
+    Zettel
+      (zettelID z)
+      (zettelTitle z)
+      (zettelTags z)
+      (zettelDay z)
+      (zettelQueries z)
+      (Right $ zettelError z)
+      (MetadataOnly ())
+
+getPandocDoc :: ZettelC -> Maybe Pandoc
+getPandocDoc = \case
+  Left _ -> Nothing
+  Right (Zettel {..}) -> Just zettelContent
+
+type family ContentError c
+
+type instance ContentError Pandoc = [QueryParseError]
+
+type instance ContentError Text = ZettelParseError
+
+type instance ContentError MetadataOnly = Either (ContentError Text) (ContentError Pandoc)
+
+type ZettelError = Either ZettelParseError (NonEmpty QueryError)
 
 -- | A zettel with the associated pandoc AST
 newtype PandocZettel = PandocZettel {unPandocZettel :: (Zettel, Pandoc)}
   deriving (Eq)
 
-instance Eq Zettel where
+-- old approach:
+-- Zettel with content
+--
+-- The content is either parsed Pandoc doc, or the raw content (when parsing has
+-- failed)
+data ZwC = ZwC (Zettel, Either Text Pandoc)
+
+instance Eq (ZettelT c) where
   (==) = (==) `on` zettelID
 
-instance Ord Zettel where
+instance Ord (ZettelT c) where
   compare = compare `on` zettelID
 
-instance Show Zettel where
+instance Show (ZettelT c) where
   show Zettel {..} = "Zettel:" <> show zettelID
 
-instance Vertex Zettel where
-  type VertexID Zettel = ZettelID
+instance Vertex (ZettelT c) where
+  type VertexID (ZettelT c) = ZettelID
   vertexID = zettelID
 
 sortZettelsReverseChronological :: [Zettel] -> [Zettel]

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
@@ -6,7 +6,6 @@
 module Neuron.Zettelkasten.Zettel.Parser where
 
 import Control.Monad.Writer
-import qualified Data.Map.Strict as Map
 import Data.Some
 import Neuron.Markdown
 import Neuron.Zettelkasten.ID
@@ -14,7 +13,6 @@ import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Parser (queryFromURILink)
 import Neuron.Zettelkasten.Zettel
 import qualified Neuron.Zettelkasten.Zettel.Meta as Meta
-import Reflex.Class (filterLeft, filterRight)
 import Reflex.Dom.Pandoc.URILink (queryURILinks)
 import Relude
 import Text.Pandoc.Definition (Pandoc)
@@ -25,18 +23,21 @@ import Text.Pandoc.Definition (Pandoc)
 parseZettel ::
   ZettelID ->
   Text ->
-  Either ZettelParseError PandocZettel
+  ZettelC
 parseZettel zid s = do
-  (meta, doc) <- parseMarkdown (zettelIDSourceFileName zid) s
-  let title = maybe "Missing title" Meta.title meta
-      tags = fromMaybe [] $ Meta.tags =<< meta
-      day = case zid of
-        -- We ignore the "data" meta field on legacy Date IDs, which encode the
-        -- creation date in the ID.
-        ZettelDateID v _ -> Just v
-        ZettelCustomID _ -> Meta.date =<< meta
-      (queries, errors) = runWriter $ extractQueries doc
-  pure $ PandocZettel (Zettel zid title tags day (queries, errors), doc)
+  case parseMarkdown (zettelIDSourceFileName zid) s of
+    Left parseErr ->
+      Left $ Zettel zid "Unknown" [] Nothing [] parseErr s
+    Right (meta, doc) ->
+      let title = maybe "Missing title" Meta.title meta
+          tags = fromMaybe [] $ Meta.tags =<< meta
+          day = case zid of
+            -- We ignore the "data" meta field on legacy Date IDs, which encode the
+            -- creation date in the ID.
+            ZettelDateID v _ -> Just v
+            ZettelCustomID _ -> Meta.date =<< meta
+          (queries, errors) = runWriter $ extractQueries doc
+       in Right $ Zettel zid title tags day queries errors doc
   where
     -- Extract all (valid) queries from the Pandoc document
     extractQueries :: MonadWriter [QueryParseError] m => Pandoc -> m [Some ZettelQuery]
@@ -52,16 +53,8 @@ parseZettel zid s = do
 -- | Like `parseZettel` but operates on multiple files.
 parseZettels ::
   [(FilePath, Text)] ->
-  ( [PandocZettel],
-    -- List of zettel files that cannot be parsed.
-    Map ZettelID ZettelParseError
-  )
+  [ZettelC]
 parseZettels fs =
-  let res = flip mapMaybe fs $ \(f, s) ->
-        case getZettelID f of
-          Nothing -> Nothing
-          Just zid ->
-            Just $ first (zid,) $ parseZettel zid s
-      errors = filterLeft res
-      zs = filterRight res
-   in (zs, Map.fromList errors)
+  flip mapMaybe fs $ \(path, s) -> do
+    zid <- getZettelID path
+    pure $ parseZettel zid s

--- a/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
@@ -19,12 +19,21 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  let noQueries = mempty -- TODO: test queries
+      noError = Right mempty
+      noContent = MetadataOnly ()
   describe "sortZettelsReverseChronological" $ do
     let mkDay = fromGregorian 2020 3
         (_ :: Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
-        noQueries = (mempty, mempty) -- TODO: test queries
         mkZettel day idx =
-          Zettel (ZettelDateID (mkDay day) idx) "Some title" [Tag "science", Tag "journal/class"] (Just $ mkDay day) noQueries
+          Zettel
+            (ZettelDateID (mkDay day) idx)
+            "Some title"
+            [Tag "science", Tag "journal/class"]
+            (Just $ mkDay day)
+            noQueries
+            noError
+            noContent
     it "sorts correctly" $ do
       let zs = [mkZettel 3 2, mkZettel 5 1]
       sortZettelsReverseChronological zs
@@ -32,9 +41,16 @@ spec = do
   describe "Zettel JSON" $ do
     let day = fromGregorian 2020 3 19
         zid = ZettelCustomID "Foo-Bar"
-        noQueries = (mempty, mempty) -- TODO: test queries
         (_ :: Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
-        zettel = Zettel zid "Some title" [Tag "science", Tag "journal/class"] (Just day) noQueries
+        zettel =
+          Zettel
+            zid
+            "Some title"
+            [Tag "science", Tag "journal/class"]
+            (Just day)
+            noQueries
+            noError
+            noContent
     it "Produces expected json" $ do
       -- "{\"id\":\"2011401\",\"title\":\"Some title\",\"tags\":[\"science\"]}"
       object (zettelJson zettel)


### PR DESCRIPTION
Resolves #215

- [x] Links to raw zettels (which use a placeholder title) should render with a red border
- [x] Eliminate dead code and refactor