### PR TITLE
Make title and YAML block optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Introduce new "uplink tree" view (#195)
 - Resilient error handling (#202, #215)
 - Added `neuron query --graph` to get the entire graph as JSON export
-- YAML block is now optional, and native Markdown H1 titles are supported (#230)
+- YAML block is now optional; title is also optional, while native Markdown H1 titles are now supported (#230)
 - Bug fixes
   - Fix 'neuron new' generating invalid Markdown when title contains special characters (#163)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Introduce new "uplink tree" view (#195)
 - Resilient error handling (#202, #215)
 - Added `neuron query --graph` to get the entire graph as JSON export
+- YAML block is now optional, and native Markdown H1 titles are supported (#230)
 - Bug fixes
   - Fix 'neuron new' generating invalid Markdown when title contains special characters (#163)
 

--- a/guide/2011401.md
+++ b/guide/2011401.md
@@ -1,6 +1,4 @@
----
-title: Zettelkasten
----
+# Zettelkasten
 
 Zettelkasten is a smart note taking system created by a German sociologist, whose productivity increased to epic proportions due to it[^dclear]. 
 

--- a/guide/2011402.md
+++ b/guide/2011402.md
@@ -1,6 +1,4 @@
----
-title: Guide
----
+# Guide
 
 Neuron includes a web interface for your notes that update automatically. This very site you are viewing is managed by neuron; and you may access its notes [here](https://github.com/srid/neuron/tree/master/guide). The "zettel" you are viewing currently is conceptually termed an "overview zettel", as it provides a portal into the other zettels. 
 

--- a/guide/2011403.md
+++ b/guide/2011403.md
@@ -1,6 +1,4 @@
----
-title: Zettel ID
----
+# Zettel ID
 
 A Zettel ID is an unique identifier that refers to a particular zettel. By
 default, neuron will use random alphanumeric IDs of length 8. But you may

--- a/guide/2011404.md
+++ b/guide/2011404.md
@@ -1,6 +1,4 @@
----
-title: Zettel Markdown
----
+# Zettel Markdown
 
 Zettel files are written using Markdown, per the [CommonMark](https://commonmark.org/) specification. Neuron uses [commonmark-hs](https://github.com/jgm/commonmark-hs) to parse them into the [Pandoc AST](https://pandoc.org/using-the-pandoc-api.html), as well as provides an extention on top to handle zettel links.
 

--- a/guide/2011405.md
+++ b/guide/2011405.md
@@ -1,6 +1,4 @@
----
-title: Web interface
----
+# Web interface
 
 Neuron can generate HTML out of your zettelkasten so that they may be viewed on any other device's web browser. It generates the HTML files under your Zettelkasten directory (by default at `~/zettelkasten`), in `.neuron/output/`, as well as spin up a server that will serve that generated site at [localhost:8080](http://localhost:8080).
 

--- a/guide/2011406.md
+++ b/guide/2011406.md
@@ -1,8 +1,9 @@
 ---
-title: Creating and Editing zettels
 tags:
   - walkthrough
 ---
+
+# Creating and Editing zettels
 
 You may use any text editor with Markdown support to edit your zettel files. Neuron provides a command to create new zettel files with the suitable <2011403?cf>:
 

--- a/guide/2011407.md
+++ b/guide/2011407.md
@@ -1,6 +1,4 @@
----
-title: Heterarchy
----
+# Heterarchy
 
 Traditional note taking methods, including outliners (Workflowy, Dynalist) necessitate creation of *preconceived* hierarchies, built "top-down". In contrast, the **heterarchy** of Zettelkasten is built organically from "bottom-up" via gradual forming of links between the notes.
 

--- a/guide/2011501.md
+++ b/guide/2011501.md
@@ -1,6 +1,4 @@
----
-title: Installing
----
+# Installing
 
 Neuron can be installed on Linux and macOS using the Nix package manager.
 

--- a/guide/2011502.md
+++ b/guide/2011502.md
@@ -1,8 +1,9 @@
 ---
-title: Tutorial
 tags:
   - walkthrough
 ---
+
+# Tutorial
 
 Make sure you have already installed neuron (see <2011501?cf>). Then follow this tutorial to get your own Zettelkasten up and running.
 

--- a/guide/2011502.md
+++ b/guide/2011502.md
@@ -50,9 +50,8 @@ Next, create an "overview" zettel called `index.md` --- it would be the welcomin
 
 ```bash
 $ cat > ~/zettelkasten/index.md
----
-title: Overview
----
+# Overview
+
 * <2011501>
 ^D
 $

--- a/guide/2011503.md
+++ b/guide/2011503.md
@@ -1,6 +1,4 @@
----
-title: Graph view
----
+# Graph view
 
 A zettelkasten is a [directed graph](https://en.wikipedia.org/wiki/Directed_graph), and <2017401> is a subset of this graph established by having zettels branch off to other zettels.
 

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -1,6 +1,4 @@
----
-title: Linking
----
+# Linking
 
 To link to another zettel, use the following syntax:
 

--- a/guide/2011505.md
+++ b/guide/2011505.md
@@ -1,6 +1,4 @@
----
-title: Zettel metadata
----
+# Zettel metadata
 
 Every zettel must contain a "title" field in its metadata. Option metadata include "tags" and "date".
 

--- a/guide/2011505.md
+++ b/guide/2011505.md
@@ -8,7 +8,6 @@ You can attach one or more tags to your zettels:
 
 ```markdown
 ---
-title: Gravity
 tags:
   - science
 ---
@@ -22,7 +21,6 @@ The creation date of the zettels can be specified in the "date" metadata field (
 
 ```markdown
 ---
-title: Ate steak for birthday
 date: 2020-04-07
 tags:
   - journal

--- a/guide/2011505.md
+++ b/guide/2011505.md
@@ -1,6 +1,6 @@
 # Zettel metadata
 
-Every zettel must contain a "title" field in its metadata. Option metadata include "tags" and "date".
+Zettels may contain optional metadata, that include "tags" and "date".
 
 ## Tags
 

--- a/guide/2011506.md
+++ b/guide/2011506.md
@@ -1,6 +1,4 @@
----
-title: Automatic links using queries
----
+# Automatic links using queries
 
 Neuron supports special link syntax that will query the Zettelkasten (eg: by tag) and insert the links using the query results.
 

--- a/guide/2011701.md
+++ b/guide/2011701.md
@@ -1,6 +1,4 @@
----
-title: Configuration
----
+# Configuration
 
 You may configure the parameters of your web interface by adding an optional configuration file named `neuron.dhall` under the notes directory. It should contain:
 

--- a/guide/2012101.md
+++ b/guide/2012101.md
@@ -1,6 +1,4 @@
----
-title: Atomic and autonomous
----
+# Atomic and autonomous
 
 Zettelkasten notes are atomic and autonomous.
 

--- a/guide/2012301.md
+++ b/guide/2012301.md
@@ -1,6 +1,4 @@
----
-title: Clusters
----
+# Clusters
 
 Your Zettelkasten may have two or more clusters, not [connected](https://en.wikipedia.org/wiki/Connected_graph) to one another.  The z-index will display these clusters, with each cluster's <2017401?cf> rendered as a [forest](https://tinyurl.com/wikipedia-forest), whose roots (aka "[mother](https://www.geeksforgeeks.org/find-a-mother-vertex-in-a-graph/) zettels") could be considered as a portal zettel into that sub-Zettelkasten.
 

--- a/guide/2012401.md
+++ b/guide/2012401.md
@@ -1,6 +1,4 @@
----
-title: Declarative Install
----
+# Declarative Install
 
 If you use [NixOS](https://nixos.org/), add the following to your `environment.systemPackages` list:
 

--- a/guide/2013101.md
+++ b/guide/2013101.md
@@ -1,6 +1,4 @@
----
-title: Examples
----
+# Examples
 
 Here is a list of public Zettelkastens that are managed by neuron:
 

--- a/guide/2013501.md
+++ b/guide/2013501.md
@@ -27,7 +27,7 @@ See asciinema: <https://asciinema.org/a/313358>
 
 ### Full-text search
 
-The `--full-text` (alias: `-a`) option can be used to search by the whole content, not just title:
+The `--full-text` (alias: `-a`) option can be used to search by the whole content, not just the title:
 
 ```bash
 neuron search -a

--- a/guide/2013501.md
+++ b/guide/2013501.md
@@ -1,8 +1,9 @@
 ---
-title: Searching your Zettelkasten
 tags:
   - walkthrough
 ---
+
+# Searching your Zettelkasten
 
 ## Interactive search
 

--- a/guide/2013701.md
+++ b/guide/2013701.md
@@ -1,6 +1,4 @@
----
-title: Math support
----
+# Math support
 
 Neuron's Markdown syntax supports [MathJax](https://www.mathjax.org/).
 

--- a/guide/2013702.md
+++ b/guide/2013702.md
@@ -1,6 +1,4 @@
----
-title: Code syntax highlighting
----
+# Code syntax highlighting
 
 Syntax highlighting is builtin. To activate highlighting, your [fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) must contain a language identifier (see [example](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting)).
 

--- a/guide/2014401.md
+++ b/guide/2014401.md
@@ -1,6 +1,4 @@
----
-title: MMark Limitations
----
+# MMark Limitations
 
 {.ui .warning .message}
 **NOTE**: This page only applies to neuron version 0.4 or below, which used the mmark Markdown parser. Beginning from neuron version 0.5, however, Pandoc (via commonmark-hs) is used to represent Markdown, where these limitations do not apply. This page is left here for legacy reference. See [issue #137](https://github.com/srid/neuron/issues/137) for details.

--- a/guide/2014601.md
+++ b/guide/2014601.md
@@ -1,7 +1,4 @@
----
-title: Themes
----
-
+# Themes
 
 Themes can be configured in the <2011701?cf> file.
 

--- a/guide/2016401.md
+++ b/guide/2016401.md
@@ -1,6 +1,4 @@
----
-title: Adding images and other files
----
+# Adding images and other files
 
 Create a folder named "static" in your Zettelkasten directory, and add your
 images and files to it. Neuron will automatically copy them as is to the output

--- a/guide/2017401.md
+++ b/guide/2017401.md
@@ -1,6 +1,4 @@
----
-title: Folgezettel Heterarchy
----
+# Folgezettel Heterarchy
 
 Neuron allows you to organically build a <2011407?cf> out of your Zettelkasten over time. This is achieved by <2011504?cf> *without* the `cf` flag. When a zettel links to another, it "branches of"[^folge] to that zettel ... unless `cf` is used (in which case it is not a branch off). 
 

--- a/guide/4a6b25f1.md
+++ b/guide/4a6b25f1.md
@@ -1,6 +1,4 @@
----
-title: Editor integration
----
+# Editor integration
 
 While you may use any text editor with neuron, the following extensions enable certain neuron-specific features on top of basic text editing.
 

--- a/guide/535407ad.md
+++ b/guide/535407ad.md
@@ -1,7 +1,4 @@
----
-title: Hierarchical tags
-date: 2020-05-08
----
+# Hierarchical tags
 
 Tags can be nested using a "tag/subtag" syntax, to allow a more fine-grained organization of your Zettelkasten, especially when using advanced queries as shown in <2011506?cf>.
 

--- a/guide/535407ad.md
+++ b/guide/535407ad.md
@@ -6,10 +6,11 @@ For example, the following zettel is tagged "math/calculus/definition"
 
 ```markdown
 ---
-title: Derivative
 tags:
   - math/calculus/definition
 ---
+
+# Derivative
 ```
 
 It will be included in the following tag queries:

--- a/guide/6f0f0bcc.md
+++ b/guide/6f0f0bcc.md
@@ -1,6 +1,4 @@
----
-title: Philosophy
----
+# Philosophy
 
 Neuron was designed with these criteria in mind:
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -1,7 +1,4 @@
----
-title: Neuron Zettelkasten
----
-
+# Neuron Zettelkasten
 
 [Neuron](https://github.com/srid/neuron) is an open-source CLI app for managing your plain-text notes in <2011401> style, as well as for publishing them on the web. Read its <6f0f0bcc>.
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.5.4.0
+version: 0.5.5.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -7,7 +7,7 @@ SEARCHFROMFIELD=${3}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${4})
 cd ${NOTESDIR}
 rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" *.md \
-  | fzf --tac --no-sort -d ':' -n ${SEARCHFROMFIELD}.. \
+  | fzf --tac --no-sort -d ' ' -n ${SEARCHFROMFIELD}.. \
     --preview 'bat --style=plain --color=always {1}' \
   | awk -F: "{printf \"${NOTESDIR}/%s\", \$1}" \
   | xargs -r ${OPENCMD}

--- a/neuron/src/app/Neuron/CLI/New.hs
+++ b/neuron/src/app/Neuron/CLI/New.hs
@@ -53,9 +53,10 @@ newZettelFile NewCommand {..} = do
           T.intercalate
             "\n"
             [ "---",
-              "title: " <> T.strip (decodeUtf8 (YAML.encode1 title)),
               "date: " <> T.strip (decodeUtf8 (YAML.encode1 day)),
               "---",
+              "",
+              "# " <> T.strip title,
               "\n"
             ]
         fileAction path

--- a/neuron/src/app/Neuron/CLI/Search.hs
+++ b/neuron/src/app/Neuron/CLI/Search.hs
@@ -23,7 +23,7 @@ searchScriptArgs :: SearchCommand -> [String]
 searchScriptArgs SearchCommand {..} =
   let searchByArgs =
         case searchBy of
-          SearchByTitle -> ["(^# )|(^title: )", "3"]
+          SearchByTitle -> ["(^# )|(^title: )", "2"]
           SearchByContent -> ["", "2"]
       editArg =
         bool "echo" "$EDITOR" searchEdit

--- a/neuron/src/app/Neuron/CLI/Search.hs
+++ b/neuron/src/app/Neuron/CLI/Search.hs
@@ -23,7 +23,7 @@ searchScriptArgs :: SearchCommand -> [String]
 searchScriptArgs SearchCommand {..} =
   let searchByArgs =
         case searchBy of
-          SearchByTitle -> ["title: ", "3"]
+          SearchByTitle -> ["(^# )|(^title: )", "3"]
           SearchByContent -> ["", "2"]
       editArg =
         bool "echo" "$EDITOR" searchEdit

--- a/neuron/src/lib/Neuron/Web/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/View.hs
@@ -115,7 +115,8 @@ renderZettelContent ::
   NeuronWebT t m ()
 renderZettelContent handleLink Zettel {..} = do
   elClass "article" "ui raised attached segment zettel-content" $ do
-    elClass "h1" "header" $ text zettelTitle
+    unless zettelTitleInBody $ do
+      el "h1" $ text zettelTitle
     void $ elPandoc (Config handleLink) zettelContent
     whenJust zettelDay $ \day ->
       elAttr "div" ("class" =: "date" <> "title" =: "Zettel creation date") $ do

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -51,6 +51,7 @@ data ZettelQuery r where
 data ZettelT content = Zettel
   { zettelID :: ZettelID,
     zettelTitle :: Text,
+    zettelTitleInBody :: Bool,
     zettelTags :: [Tag],
     zettelDay :: Maybe Day,
     zettelQueries :: [Some ZettelQuery],

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Meta.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Meta.hs
@@ -19,7 +19,7 @@ import Relude
 
 -- | YAML metadata in a zettel markdown file
 data Meta = Meta
-  { title :: Text,
+  { title :: Maybe Text,
     tags :: Maybe [Tag],
     -- | Creation day
     date :: Maybe Day
@@ -30,7 +30,7 @@ instance FromYAML Meta where
   parseYAML =
     withMap "Meta" $ \m ->
       Meta
-        <$> m .: "title"
+        <$> m .:? "title"
         <*> m .:? "tags"
         <*> m .:? "date"
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel/Parser.hs
@@ -7,7 +7,7 @@ module Neuron.Zettelkasten.Zettel.Parser where
 
 import Control.Monad.Writer
 import Data.Some
-import Neuron.Markdown
+import Neuron.Markdown (getH1, parseMarkdown, plainify)
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Parser (queryFromURILink)
@@ -27,9 +27,12 @@ parseZettel ::
 parseZettel zid s = do
   case parseMarkdown (zettelIDSourceFileName zid) s of
     Left parseErr ->
-      Left $ Zettel zid "Unknown" [] Nothing [] parseErr s
+      Left $ Zettel zid "Unknown" False [] Nothing [] parseErr s
     Right (meta, doc) ->
-      let title = maybe "Missing title" Meta.title meta
+      let (title, titleInBody) = case Meta.title =<< meta of
+            Just tit -> (tit, False)
+            Nothing -> fromMaybe ("Untitled", False) $ do
+              (,True) . plainify <$> getH1 doc
           tags = fromMaybe [] $ Meta.tags =<< meta
           day = case zid of
             -- We ignore the "data" meta field on legacy Date IDs, which encode the
@@ -37,7 +40,7 @@ parseZettel zid s = do
             ZettelDateID v _ -> Just v
             ZettelCustomID _ -> Meta.date =<< meta
           (queries, errors) = runWriter $ extractQueries doc
-       in Right $ Zettel zid title tags day queries errors doc
+       in Right $ Zettel zid title titleInBody tags day queries errors doc
   where
     -- Extract all (valid) queries from the Pandoc document
     extractQueries :: MonadWriter [QueryParseError] m => Pandoc -> m [Some ZettelQuery]

--- a/neuron/test/Neuron/VersionSpec.hs
+++ b/neuron/test/Neuron/VersionSpec.hs
@@ -28,10 +28,10 @@ spec = do
       "0.4" `isLesserOrEqual` olderThan
     it "full versions" $ do
       "0.6.1.2" `isGreater` olderThan
-      "0.5.5" `isGreater` olderThan
-      "0.5.4.8" `isGreater` olderThan
-      "0.5.4.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.6" `isGreater` olderThan
+      "0.5.5.8" `isGreater` olderThan
+      "0.5.5.0" `isLesserOrEqual` olderThan -- This is current version
       "0.3.1.0" `isLesserOrEqual` olderThan
     it "within same major version" $ do
-      "0.5.4.8" `isGreater` olderThan
-      "0.5.4.0" `isLesserOrEqual` olderThan -- This is current version
+      "0.5.5.8" `isGreater` olderThan
+      "0.5.5.0" `isLesserOrEqual` olderThan -- This is current version

--- a/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/ZettelSpec.hs
@@ -24,11 +24,12 @@ spec = do
       noContent = MetadataOnly ()
   describe "sortZettelsReverseChronological" $ do
     let mkDay = fromGregorian 2020 3
-        (_ :: Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
+        (_ :: Maybe Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
         mkZettel day idx =
           Zettel
             (ZettelDateID (mkDay day) idx)
             "Some title"
+            False
             [Tag "science", Tag "journal/class"]
             (Just $ mkDay day)
             noQueries
@@ -41,11 +42,12 @@ spec = do
   describe "Zettel JSON" $ do
     let day = fromGregorian 2020 3 19
         zid = ZettelCustomID "Foo-Bar"
-        (_ :: Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
+        (_ :: Maybe Meta, _dummyContent) = either (error . show) id $ parseMarkdown "<spec>" "Dummy"
         zettel =
           Zettel
             zid
             "Some title"
+            False
             [Tag "science", Tag "journal/class"]
             (Just day)
             noQueries


### PR DESCRIPTION
If no title is specified, use the H1 title (as raw string). If that is missing, use the first few letters of the first paragraph. Otherwise, use "Untitled".

Resolves #181