### PR TITLE
Make neuron new title argument optional (fix #232)

### DIFF
--- a/neuron/src/app/Neuron/CLI/New.hs
+++ b/neuron/src/app/Neuron/CLI/New.hs
@@ -51,14 +51,16 @@ newZettelFile NewCommand {..} = do
       liftIO $ do
         fileAction :: FilePath -> FilePath -> IO () <-
           bool (pure showAction) mkEditActionFromEnv edit
+        let date = T.strip (decodeUtf8 (YAML.encode1 day))
+            defaultTitleName = "Zettel created on " <> date
         writeFileText (notesDir </> zettelFile) $
           T.intercalate
             "\n"
             [ "---",
-              "date: " <> T.strip (decodeUtf8 (YAML.encode1 day)),
+              "date: " <> date,
               "---",
               "",
-              "# " <> T.strip title,
+              "# " <> maybe defaultTitleName T.strip title,
               "\n"
             ]
         fileAction notesDir zettelFile

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -20,7 +20,6 @@ where
 import Data.Default (def)
 import Data.Some
 import Data.TagTree (mkTagPattern)
-import qualified Data.Text as T
 import Data.Time
 import Neuron.Zettelkasten.ID (ZettelID, parseZettelID')
 import Neuron.Zettelkasten.ID.Scheme (IDScheme (..))
@@ -40,7 +39,7 @@ data App = App
   }
 
 data NewCommand = NewCommand
-  { title :: Text,
+  { title :: Maybe Text,
     day :: Day,
     idScheme :: Some IDScheme,
     edit :: Bool
@@ -101,7 +100,7 @@ commandParser defaultNotesDir today = do
             command "rib" $ info ribCommand $ progDesc "Generate static site via rib"
           ]
     newCommand = do
-      title <- argument nonEmptyTextReader (metavar "TITLE" <> help "Title of the new Zettel")
+      title <- optional $ strArgument (metavar "TITLE" <> help "Title of the new Zettel")
       edit <- switch (long "edit" <> short 'e' <> help "Open the newly-created zettel in $EDITOR")
       day <-
         option dayReader $
@@ -165,12 +164,6 @@ commandParser defaultNotesDir today = do
           either (Left . toString . Q.showQueryParseError) (maybe (Left "Unsupported query") Right) $ Q.queryFromURI uri
         Left e ->
           Left $ displayException e
-    nonEmptyTextReader :: ReadM Text
-    nonEmptyTextReader =
-      eitherReader $ \(T.strip . toText -> s) ->
-        if T.null s
-          then Left "Empty text is not allowed"
-          else Right s
     dayReader :: ReadM Day
     dayReader =
       maybeReader (parseZettelDate . toText)


### PR DESCRIPTION
Late Zurihac PR `:P`

Now, if the user does not pass an argument for the title, a default '# Zettel created on <date>' is used.

Made the change in the action that writes the file instead of in the command line parser because that is written with an applicative parser so I couldn't figure out if I could use the value of a parameter (date) to build the default for another parameter (title).

fixes #232 