### PR TITLE
Make graph queries output JSON that is consistent with zettel queries

### DIFF
--- a/neuron/src/app/Neuron/CLI.hs
+++ b/neuron/src/app/Neuron/CLI.hs
@@ -72,6 +72,6 @@ runWith act App {..} =
           Right someQ ->
             withSome someQ $ \q -> do
               let result = Q.runGraphQuery graph q
-              putLTextLn $ Aeson.encodeToLazyText $ Q.graphQueryResultJson q result errors
+              putLTextLn $ Aeson.encodeToLazyText $ Q.graphQueryResultJson notesDir q result errors
     Search searchCmd ->
       interactiveSearch notesDir searchCmd

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
@@ -13,7 +13,6 @@ module Neuron.Zettelkasten.Graph
     -- * Graph functions
     getZettels,
     getZettel,
-    getConnections,
     getConnection,
     topSort,
     frontlinkForest,
@@ -30,7 +29,6 @@ import qualified Algebra.Graph.Labelled.AdjacencyMap as LAM
 import Data.Default
 import Data.Foldable (maximum)
 import qualified Data.Graph.Labelled as G
-import qualified Data.Map.Strict as Map
 import Data.Tree
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph.Type
@@ -101,9 +99,6 @@ getZettels = G.getVertices
 
 getZettel :: ZettelID -> ZettelGraph -> Maybe Zettel
 getZettel = G.findVertex
-
-getConnections :: ZettelGraph -> Map.Map ZettelID (Map.Map ZettelID (Maybe Connection))
-getConnections = LAM.adjacencyMap . G.getGraph
 
 -- | If no connection exists, this returns Nothing.
 getConnection :: Zettel -> Zettel -> ZettelGraph -> Maybe Connection

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
@@ -13,6 +13,7 @@ module Neuron.Zettelkasten.Graph
     -- * Graph functions
     getZettels,
     getZettel,
+    getConnections,
     getConnection,
     topSort,
     frontlinkForest,
@@ -29,6 +30,7 @@ import qualified Algebra.Graph.Labelled.AdjacencyMap as LAM
 import Data.Default
 import Data.Foldable (maximum)
 import qualified Data.Graph.Labelled as G
+import qualified Data.Map.Strict as Map
 import Data.Tree
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.Graph.Type
@@ -99,6 +101,9 @@ getZettels = G.getVertices
 
 getZettel :: ZettelID -> ZettelGraph -> Maybe Zettel
 getZettel = G.findVertex
+
+getConnections :: ZettelGraph -> Map.Map ZettelID (Map.Map ZettelID (Maybe Connection))
+getConnections = LAM.adjacencyMap . G.getGraph
 
 -- | If no connection exists, this returns Nothing.
 getConnection :: Zettel -> Zettel -> ZettelGraph -> Maybe Connection

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -17,15 +17,13 @@ module Neuron.Zettelkasten.Query
   )
 where
 
-import qualified Algebra.Graph.Labelled.AdjacencyMap as LAM
 import Control.Monad.Except
 import Data.Aeson
-import qualified Data.Graph.Labelled as G
 import qualified Data.Map.Strict as Map
 import Data.TagTree (Tag, tagMatch, tagMatchAny, tagTree)
 import Data.Tree (Tree (..))
 import Neuron.Zettelkasten.Connection
-import Neuron.Zettelkasten.Graph (backlinks, getZettel)
+import Neuron.Zettelkasten.Graph (backlinks, getConnections, getZettel)
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
@@ -130,11 +128,9 @@ graphQueryResultJson notesDir q er skippedZettels =
     edgeJson :: Connection -> Zettel -> Value
     edgeJson connection zettel =
       object $ ["connection" .= toJSON connection] <> zettelJsonFull notesDir zettel
-    graphConnections :: ZettelGraph -> Map.Map ZettelID (Map.Map ZettelID (Maybe Connection))
-    graphConnections = LAM.adjacencyMap . G.getGraph
     resultJson :: r -> Value
     resultJson r = case q of
       GraphQuery_Id ->
-        toJSON (graphConnections r)
+        toJSON (getConnections r)
       GraphQuery_BacklinksOf _ _ ->
         toJSON $ fmap (uncurry edgeJson) r

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -17,13 +17,15 @@ module Neuron.Zettelkasten.Query
   )
 where
 
+import qualified Algebra.Graph.Labelled.AdjacencyMap as LAM
 import Control.Monad.Except
 import Data.Aeson
+import qualified Data.Graph.Labelled as G
 import qualified Data.Map.Strict as Map
 import Data.TagTree (Tag, tagMatch, tagMatchAny, tagTree)
 import Data.Tree (Tree (..))
 import Neuron.Zettelkasten.Connection
-import Neuron.Zettelkasten.Graph (backlinks, getConnections, getZettel)
+import Neuron.Zettelkasten.Graph (backlinks, getZettel)
 import Neuron.Zettelkasten.Graph.Type
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
@@ -128,9 +130,11 @@ graphQueryResultJson notesDir q er skippedZettels =
     edgeJson :: Connection -> Zettel -> Value
     edgeJson connection zettel =
       object $ ["connection" .= toJSON connection] <> zettelJsonFull notesDir zettel
+    graphConnections :: ZettelGraph -> Map.Map ZettelID (Map.Map ZettelID (Maybe Connection))
+    graphConnections = LAM.adjacencyMap . G.getGraph
     resultJson :: r -> Value
     resultJson r = case q of
       GraphQuery_Id ->
-        toJSON (getConnections r)
+        toJSON (graphConnections r)
       GraphQuery_BacklinksOf _ _ ->
         toJSON $ fmap (uncurry edgeJson) r

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -119,7 +119,5 @@ graphQueryResultJson notesDir q er skippedZettels =
     resultJson r = case q of
       GraphQuery_Id ->
         toJSON (getConnections r)
-      GraphQuery_BacklinksOf Nothing _ ->
+      GraphQuery_BacklinksOf _ _ ->
         toJSON $ fmap (uncurry edgeJson) r
-      GraphQuery_BacklinksOf Just {} _ ->
-        toJSON $ fmap (\(_, zettel) -> object $ zettelJsonFull notesDir zettel) r

--- a/neuron/src/lib/Neuron/Zettelkasten/Query.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query.hs
@@ -9,7 +9,13 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | Queries to the Zettel store
-module Neuron.Zettelkasten.Query where
+module Neuron.Zettelkasten.Query
+  ( runZettelQuery,
+    runGraphQuery,
+    zettelQueryResultJson,
+    graphQueryResultJson,
+  )
+where
 
 import Control.Monad.Except
 import Data.Aeson
@@ -24,6 +30,7 @@ import Neuron.Zettelkasten.Query.Error (QueryResultError (..))
 import Neuron.Zettelkasten.Query.Graph
 import Neuron.Zettelkasten.Zettel
 import Relude
+import System.FilePath
 
 runZettelQuery :: [Zettel] -> ZettelQuery r -> Either QueryResultError r
 runZettelQuery zs = \case
@@ -56,6 +63,12 @@ runGraphQuery g = \case
         Left $ QueryResultError_NoSuchZettel zid
       Just z ->
         Right $ backlinks (maybe isJust (const (== conn)) conn) z g
+
+zettelJsonFull :: forall a. KeyValue a => FilePath -> Zettel -> [a]
+zettelJsonFull notesDir z@Zettel {..} =
+  [ "path" .= (notesDir </> zettelIDSourceFileName zettelID)
+  ]
+    <> zettelJson z
 
 zettelQueryResultJson ::
   forall r.

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -34,7 +34,6 @@ import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
 import Relude hiding (show)
-import System.FilePath
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Show (Show (show))
 
@@ -123,12 +122,6 @@ zettelJson Zettel {..} =
     "tags" .= zettelTags,
     "day" .= zettelDay
   ]
-
-zettelJsonFull :: forall a. KeyValue a => FilePath -> Zettel -> [a]
-zettelJsonFull notesDir z@Zettel {..} =
-  [ "path" .= (notesDir </> zettelIDSourceFileName zettelID)
-  ]
-    <> zettelJson z
 
 deriveJSONGADT ''ZettelQuery
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -34,6 +34,7 @@ import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
 import Neuron.Zettelkasten.Query.Theme
 import Relude hiding (show)
+import System.FilePath
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Show (Show (show))
 
@@ -122,6 +123,12 @@ zettelJson Zettel {..} =
     "tags" .= zettelTags,
     "day" .= zettelDay
   ]
+
+zettelJsonFull :: forall a. KeyValue a => FilePath -> Zettel -> [a]
+zettelJsonFull notesDir z@Zettel {..} =
+  [ "path" .= (notesDir </> zettelIDSourceFileName zettelID)
+  ]
+    <> zettelJson z
 
 deriveJSONGADT ''ZettelQuery
 


### PR DESCRIPTION
Fixes #254, needed for <https://github.com/felko/neuron-mode/issues/30>

The new JSON output looks like this:

- `--backlinks-of`
```json
{
  "skipped": {},
  "result": [
    {
      "path": "guide/2011402.md",
      "connection": "Folgezettel",
      "day": "2020-03-19",
      "id": "2011402",
      "title": "Guide",
      "tags": []
    },
    {
      "path": "guide/2011406.md",
      "connection": "OrdinaryConnection",
      "day": "2020-03-19",
      "id": "2011406",
      "title": "Creating and Editing zettels",
      "tags": [
        "walkthrough"
      ]
    },
    ...
  ],
  "query": [
    "GraphQuery_BacklinksOf",
    [
      null,
      "2011403"
    ]
  ]
}
```
- `--uplinks-of`
```json
{
  "skipped": {},
  "result": [
    {
      "path": "guide/2011402.md",
      "connection": "Folgezettel",
      "day": "2020-03-19",
      "id": "2011402",
      "title": "Guide",
      "tags": []
    }
  ],
  "query": [
    "GraphQuery_BacklinksOf",
    [
      "Folgezettel",
      "2011403"
    ]
  ]
}
```

- `--graph`
```json
{
  "skipped": {},
  "result": {
    "2011402": {
      "2013501": "Folgezettel",
      "2011404": "Folgezettel",
      "2011403": "Folgezettel",
      "cc1f7ecf": "Folgezettel",
      "2011405": "Folgezettel",
      "2011406": "Folgezettel",
      "2017401": "OrdinaryConnection"
    },
    "2013501": {},
    "6f0f0bcc": {
      "4a6b25f1": "OrdinaryConnection",
      "041726b3": "OrdinaryConnection"
    },
    ...
  },
  "query": [
    "GraphQuery_Id",
    []
  ]
}
```

Note that for the graph, the information about the zettels themselves do not appear anymore, so we only get their IDs (it only outputs the adjacency map). Not sure whether this is a good decision or not, you tell me.