### PR TITLE
Avoid requiring `builtins.currentSystem`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       run: |
         git clone https://github.com/srid/nix-bundle.git tmp/nix-bundle
         cd tmp/nix-bundle
-        ./nix-bundle.sh '(import ../..)' /bin/neuron > neuron
+        ./nix-bundle.sh '(import ../.. {})' /bin/neuron > neuron
         mkdir ~/bundle 
         cp neuron ~/bundle/neuron
         chmod a+x ~/bundle/neuron

--- a/ci.nix
+++ b/ci.nix
@@ -5,6 +5,6 @@ pkgs.recurseIntoAttrs {
   # Build both default.nix and shell.nix such that both derivations are
   # pushed to cachix. This allows the development workflow (bin/run, etc.) to
   # use cachix to full extent.
-  neuron = import ./default.nix;
-  neuronShell = import ./shell.nix;
+  neuron = import ./default.nix {};
+  neuronShell = import ./shell.nix {};
 }

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
+{ system ? builtins.currentSystem, withHoogle ? false }:
 let 
-  ghc = (import ./project.nix {}).ghc;
+  ghc = (import ./project.nix { inherit system withHoogle; }).ghc;
   neuron = ghc.neuron;
 in 
   neuron.overrideDerivation (drv: {

--- a/guide/2012401.md
+++ b/guide/2012401.md
@@ -18,7 +18,7 @@ It is generally recommended to pin your imports in Nix. The above expression wil
 # Use this for neuron 0.5 or above only.
 (let neuronRev = "GITREVHERE";
      neuronSrc = builtins.fetchTarball https://github.com/srid/neuron/archive/${neuronRev}.tar.gz;
-  in import neuronSrc)
+  in import neuronSrc {})
 ```
 
 In the future if you decide to upgrade neuron, simply change the revision hash to a newer one.

--- a/guide/6479cd5e.md
+++ b/guide/6479cd5e.md
@@ -14,7 +14,7 @@ systemd.user.services.neuron = let
   neuron = (
     let neuronRev = "GITREVHERE";
         neuronSrc = builtins.fetchTarball https://github.com/srid/neuron/archive/${neuronRev}.tar.gz;
-     in import neuronSrc);
+     in import neuronSrc {});
 in {
   Unit.Description = "Neuron zettelkasten service";
   Install.WantedBy = [ "graphical-session.target" ];

--- a/project.nix
+++ b/project.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, withHoogle ? false }:
+{ system, withHoogle }:
 (import ./dep/reflex-platform { inherit system; }).project ({ pkgs, hackGet, ... }: 
 let 
   gitignoreSrc = pkgs.fetchFromGitHub { 

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,2 @@
-(import ./project.nix {}).shells.ghc
+{ system ? builtins.currentSystem, withHoogle ? false }:
+(import ./project.nix { inherit system withHoogle; }).shells.ghc


### PR DESCRIPTION
This PR modifies the `default.nix` and `shell.nix` files to take arguments with defaults which are then provided to `project.nix` (which no longer takes arguments). 

This is necessary for systems which use [Nix flakes](https://www.tweag.io/blog/2020-05-25-flakes/), where `builtins.currentSystem` cannot be used. Previously, there was no mechanism for users to stop `project.nix` from using `builtins.currentSystem` when importing `default.nix` and so it just couldn't be imported.

Unfortunately, this is technically a breaking change - while `nix-build` will still work unchanged, importing the repository as before won't work and will need to be changed (as shown in the changes to the guide).