### PR TITLE
Update "Automatic Publishing" to include GL Pages

### DIFF
--- a/guide/778816d3.md
+++ b/guide/778816d3.md
@@ -1,7 +1,10 @@
 # Automatic Publishing
 
-There are various workflows possible to setup **automatic publishing** of your neuron notes. The simplest approach is store your notes in online repo, and use service like GitHub Pages + GitHub Actions[^this] or GitLab Pages + GitLab CI. You can give this a try instantly using `neuron-template` on [GitHub](https://github.com/srid/neuron-template) or [GitLab](https://gitlab.com/thematten/neuron-template) respectively. Follow the instructions in those links to get started.
+You can configure your neuron notes to be **automatically published** on the web. The simplest approach to achieve this is to store your notes in GitHub[^gitlab], and use their GitHub Pages + GitHub Actions[^this]. You can give this a try instantly with zero-configuration by using [`neuron-template`](https://github.com/srid/neuron-template). Follow the instructions in that link to get started. 
 
+In order to enable automatic publishing for your *existing* neuron site that is already on GitHub, begin by copying `neuron-template`'s [`.github/workflows`](https://github.com/srid/neuron-template/tree/master/.github/workflows) directory to your repository
+
+or 
 [^this]: This very site is set up to automatically publish in this manner.
 
-In order to enable automatic publishing for your *existing* neuron site that is already on GitHub, begin by copying `neuron-template`'s [`.github/workflows`](https://github.com/srid/neuron-template/tree/master/.github/workflows) directory to your repository. You can do similarly with [`.gitlab-ci.yml`](https://gitlab.com/thematten/neuron-template/-/blob/master/.gitlab-ci.yml) file on GitLab.
+[^gitlab]: If you prefer to use GitLab (and thus GitLab Pages + GitLab CI) over GitHub, checkout the unofficial template [thematten/neuron-template](https://gitlab.com/thematten/neuron-template) on GitLab. For an existing GitLab repo, you will want to copy over its [`.gitlab-ci.yml`](https://gitlab.com/thematten/neuron-template/-/blob/master/.gitlab-ci.yml).

--- a/guide/778816d3.md
+++ b/guide/778816d3.md
@@ -1,7 +1,7 @@
 # Automatic Publishing
 
-There are various workflows possible to setup **automatic publishing** of your neuron notes. The simplest approach is store your notes on a [GitHub](https://github.com/) repo, and use GitHub Pages + GitHub Actions[^this]. You can give this a try instantly using [neuron-template](https://github.com/srid/neuron-template). Follow the instructions in that link to get started.
+There are various workflows possible to setup **automatic publishing** of your neuron notes. The simplest approach is store your notes in online repo, and use service like GitHub Pages + GitHub Actions[^this] or GitLab Pages + GitLab CI. You can give this a try instantly using `neuron-template` on [GitHub](https://github.com/srid/neuron-template) or [GitLab](https://gitlab.com/thematten/neuron-template) respectively. Follow the instructions in those links to get started.
 
 [^this]: This very site is set up to automatically publish in this manner.
 
-In order to enable automatic publishing for your *existing* neuron site that is already on GitHub, begin by copying neuron-template's [`.github/workflows`](https://github.com/srid/neuron-template/tree/master/.github/workflows) directory to your repository. 
+In order to enable automatic publishing for your *existing* neuron site that is already on GitHub, begin by copying `neuron-template`'s [`.github/workflows`](https://github.com/srid/neuron-template/tree/master/.github/workflows) directory to your repository. You can do similarly with [`.gitlab-ci.yml`](https://gitlab.com/thematten/neuron-template/-/blob/master/.gitlab-ci.yml) file on GitLab.


### PR DESCRIPTION
Links to [modified version of `neuron-template`](https://gitlab.com/thematten/neuron-template) that works with GitLab Pages.