### PR TITLE
Make `docker.nix` configurable, add option to include shell

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -1,17 +1,18 @@
 # Builds a docker image containing the neuron executable
 # Run as:
-#   docker load -i $(nix-build docker.nix)
+#   docker load -i $(
+#     nix-build docker.nix \
+#       --arg name '"<image name>"' \
+#       --arg tag '"<image tag>"'
+#   )
 let
   pkgs = import <nixpkgs> {};
   neuron = import ./. {};
 in {
   name ? "sridca/neuron"
 , tag ? "test"
-, includeShell ? false
 }: pkgs.dockerTools.buildImage {
   name = name;
   tag = tag;
-  contents = [ neuron ] ++ (if includeShell
-    then [ pkgs.coreutils pkgs.bash_5 ]
-    else []);
+  contents = [ neuron pkgs.coreutils pkgs.bash_5 ];
 }

--- a/docker.nix
+++ b/docker.nix
@@ -14,5 +14,10 @@ in {
 }: pkgs.dockerTools.buildImage {
   name = name;
   tag = tag;
-  contents = [ neuron pkgs.coreutils pkgs.bash_5 ];
+  contents = [ 
+    neuron
+    # These are required for the GitLab CI runner
+    pkgs.coreutils 
+    pkgs.bash_5 
+  ];
 }

--- a/docker.nix
+++ b/docker.nix
@@ -4,10 +4,14 @@
 let
   pkgs = import <nixpkgs> {};
   neuron = import ./. {};
-in
-
-pkgs.dockerTools.buildImage {
-  name = "sridca/neuron";
-  tag = "test";
-  contents = [ neuron ];
+in {
+  name ? "sridca/neuron"
+, tag ? "test"
+, includeShell ? false
+}: pkgs.dockerTools.buildImage {
+  name = name;
+  tag = tag;
+  contents = [ neuron ] ++ (if includeShell
+    then [ pkgs.coreutils pkgs.bash_5 ]
+    else []);
 }


### PR DESCRIPTION
This makes it more convenient to build custom images (possibly with shell included) using `--arg` flags in `nix-build`.
- [x] investigate possibility of lowering shell footprint