### PR TITLE
Fix declarative install command from master branch

### DIFF
--- a/guide/2012401.md
+++ b/guide/2012401.md
@@ -5,7 +5,7 @@ If you use [NixOS](https://nixos.org/), add the following to your `environment.s
 
 ```nix
 (let neuronSrc = builtins.fetchTarball https://github.com/srid/neuron/archive/master.tar.gz;
-  in import neuronSrc)
+  in import neuronSrc {})
 ```
 
 If you use [home-manager](https://github.com/rycee/home-manager), add the above to your `home.packages` list.


### PR DESCRIPTION
Fixing a typo in the first command that results in a `x is not of type package` error when trying to add it to a package list.