### PR TITLE
Quote URLs in Nix examples

### DIFF
--- a/guide/2012401.md
+++ b/guide/2012401.md
@@ -4,7 +4,7 @@ If you use [NixOS](https://nixos.org/), add the following to your `environment.s
 
 
 ```nix
-(let neuronSrc = builtins.fetchTarball https://github.com/srid/neuron/archive/master.tar.gz;
+(let neuronSrc = builtins.fetchTarball "https://github.com/srid/neuron/archive/master.tar.gz";
   in import neuronSrc {})
 ```
 
@@ -17,7 +17,7 @@ It is generally recommended to pin your imports in Nix. The above expression wil
 ```nix
 # Use this for neuron 0.5 or above only.
 (let neuronRev = "GITREVHERE";
-     neuronSrc = builtins.fetchTarball https://github.com/srid/neuron/archive/${neuronRev}.tar.gz;
+     neuronSrc = builtins.fetchTarball "https://github.com/srid/neuron/archive/${neuronRev}.tar.gz";
   in import neuronSrc {})
 ```
 


### PR DESCRIPTION
Unquoted URLs are deprecated. (I believe. I don't remember what version did that.)