### PR TITLE
Cache zettelkasten graph JSON on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Zettel format
   - Add `unlisted` metadata property to hide a zettel from z-index (#318)
 - CLI
+  - Faster querying: add `--cached` option to `neuron query`, to run faster using the cache. To keep the cache up to date, make sure that `neuron rib` is running.
   - Add `--id` and `--search` options to `open` command to open given zettel ID or search page respectively  (#317)
 
 ## 0.6.0.0

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.6.1.0
+version: 0.6.2.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src/app/Neuron/CLI.hs
+++ b/neuron/src/app/Neuron/CLI.hs
@@ -65,12 +65,10 @@ runWith act App {..} =
         openLocallyGeneratedFile openCommand
     Query (QueryCommand {..}) ->
       runRibOnceQuietly notesDir $ do
-        readMode <-
-          bool
-            (Cache.ReadMode_Direct <$> getConfig)
-            (pure Cache.ReadMode_Cached)
-            cached
-        (graph, errors) <- Gen.loadZettelkastenGraph readMode
+        (graph, errors) <-
+          if cached
+            then Cache.getCache
+            else Gen.loadZettelkastenGraph =<< getConfig
         case query of
           Left someQ ->
             withSome someQ $ \q -> do

--- a/neuron/src/app/Neuron/CLI.hs
+++ b/neuron/src/app/Neuron/CLI.hs
@@ -23,6 +23,7 @@ import Neuron.CLI.Types (QueryCommand (..))
 import Neuron.Config (getConfig)
 import Neuron.Config.Type (Config)
 import qualified Neuron.Version as Version
+import qualified Neuron.Web.Cache as Cache
 import qualified Neuron.Web.Generate as Gen
 import qualified Neuron.Zettelkasten.Graph as G
 import qualified Neuron.Zettelkasten.Query as Q
@@ -66,8 +67,8 @@ runWith act App {..} =
       runRibOnceQuietly notesDir $ do
         readMode <-
           bool
-            (Gen.ReadMode_Direct <$> getConfig)
-            (pure Gen.ReadMode_Cached)
+            (Cache.ReadMode_Direct <$> getConfig)
+            (pure Cache.ReadMode_Cached)
             cached
         (graph, errors) <- Gen.loadZettelkastenGraph readMode
         case query of

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -158,40 +158,45 @@ commandParser defaultNotesDir today = do
             (OpenCommand . Some . R.Route_Zettel)
             (option zettelIDReader (long "id" <> help "Open the zettel HTML page" <> metavar "ID"))
     queryCommand = do
-      -- TODO: Refactor and move to new file
       cached <- switch (long "cached" <> help "Use cached zettelkasten graph (faster)")
       query <-
-        ( fmap
-            Left
-            ( fmap (Some . flip Q.ZettelQuery_ZettelByID Nothing) (option zettelIDReader (long "id"))
-                <|> fmap (\x -> Some $ Q.ZettelQuery_ZettelsByTag x Nothing def) (many (mkTagPattern <$> option str (long "tag" <> short 't')))
-                <|> option queryReader (long "uri" <> short 'u')
-            )
-            <|> fmap
-              Right
-              (fmap (const $ Some $ Q.GraphQuery_Id) $ switch (long "graph" <> help "Get the entire zettelkasten graph as JSON"))
-            <|> fmap
-              Right
-              ( fmap (Some . Q.GraphQuery_BacklinksOf Nothing) $
-                  option
-                    zettelIDReader
-                    ( long "backlinks-of"
-                        <> help "Get backlinks to the given zettel ID"
-                        <> metavar "ID"
-                    )
-              )
-            <|> fmap
-              Right
-              ( fmap (Some . Q.GraphQuery_BacklinksOf (Just C.Folgezettel)) $
-                  option
-                    zettelIDReader
-                    ( long "uplinks-of"
-                        <> help "Get uplinks to the given zettel ID"
-                        <> metavar "ID"
-                    )
-              )
+        fmap
+          Left
+          ( fmap
+              (Some . flip Q.ZettelQuery_ZettelByID Nothing)
+              (option zettelIDReader (long "id"))
+              <|> fmap
+                (\x -> Some $ Q.ZettelQuery_ZettelsByTag x Nothing def)
+                (many (mkTagPattern <$> option str (long "tag" <> short 't')))
+              <|> option queryReader (long "uri" <> short 'u')
           )
-      pure $ Query $ QueryCommand cached query
+          <|> fmap
+            Right
+            ( fmap
+                (const $ Some $ Q.GraphQuery_Id)
+                ( switch $
+                    long "graph" <> help "Get the entire zettelkasten graph as JSON"
+                )
+                <|> fmap
+                  (Some . Q.GraphQuery_BacklinksOf Nothing)
+                  ( option
+                      zettelIDReader
+                      ( long "backlinks-of"
+                          <> help "Get backlinks to the given zettel ID"
+                          <> metavar "ID"
+                      )
+                  )
+                <|> fmap
+                  (Some . Q.GraphQuery_BacklinksOf (Just C.Folgezettel))
+                  ( option
+                      zettelIDReader
+                      ( long "uplinks-of"
+                          <> help "Get uplinks to the given zettel ID"
+                          <> metavar "ID"
+                      )
+                  )
+            )
+      pure $ Query $ QueryCommand {..}
     searchCommand = do
       searchBy <-
         bool SearchByTitle SearchByContent

--- a/neuron/src/app/Neuron/Web/Cache.hs
+++ b/neuron/src/app/Neuron/Web/Cache.hs
@@ -31,6 +31,12 @@ updateCache v = do
   f <- cacheFile
   liftIO $ encodeFile f v
 
+getCache :: Action CacheData
+getCache = do
+  (liftIO . eitherDecodeFileStrict =<< cacheFile) >>= \case
+    Left err -> fail err
+    Right v -> pure v
+
 evalUnlessCacheRequested ::
   ReadMode -> (Config -> Action CacheData) -> Action CacheData
 evalUnlessCacheRequested mode f = do

--- a/neuron/src/app/Neuron/Web/Cache.hs
+++ b/neuron/src/app/Neuron/Web/Cache.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Responsible for caching zettelkasten graph on disk
+module Neuron.Web.Cache where
+
+import Data.Aeson (eitherDecodeFileStrict, encodeFile)
+import Development.Shake (Action)
+import Neuron.Config.Type (Config)
+import Neuron.Zettelkasten.Graph.Type (ZettelGraph)
+import Neuron.Zettelkasten.ID (ZettelID)
+import Neuron.Zettelkasten.Zettel (ZettelError)
+import Relude
+import Rib.Shake
+import System.FilePath
+
+data ReadMode
+  = ReadMode_Direct Config
+  | ReadMode_Cached
+  deriving (Eq, Show)
+
+type CacheData = (ZettelGraph, Map ZettelID ZettelError)
+
+cacheFile :: Action FilePath
+cacheFile = (</> ".neuron/cache.json") <$> ribInputDir
+
+updateCache :: CacheData -> Action ()
+updateCache v = do
+  f <- cacheFile
+  liftIO $ encodeFile f v
+
+evalUnlessCacheRequested ::
+  ReadMode -> (Config -> Action CacheData) -> Action CacheData
+evalUnlessCacheRequested mode f = do
+  case mode of
+    ReadMode_Direct config ->
+      f config
+    ReadMode_Cached -> do
+      (liftIO . eitherDecodeFileStrict =<< cacheFile) >>= \case
+        Left err -> fail err
+        Right v -> pure v

--- a/neuron/src/app/Neuron/Web/Generate.hs
+++ b/neuron/src/app/Neuron/Web/Generate.hs
@@ -110,12 +110,11 @@ reportError route errors = do
 --
 -- Also allows retrieving the cached data for faster execution.
 loadZettelkastenGraph ::
-  Cache.ReadMode ->
+  Config ->
   Action (ZettelGraph, Map ZettelID ZettelError)
-loadZettelkastenGraph mode =
-  Cache.evalUnlessCacheRequested mode $ \config -> do
-    (g, _, errs) <- loadZettelkasten config
-    pure (g, errs)
+loadZettelkastenGraph config = do
+  (g, _, errs) <- loadZettelkasten config
+  pure (g, errs)
 
 loadZettelkasten ::
   Config ->


### PR DESCRIPTION
Cache the zettelkasten graph on disk, and add a `--cached` option to `neuron query` for speed. The cache is updated only by `neuron rib`. The cache file is stored at `.neuron/cache.json`.

Addresses a part of #321 