### PR TITLE
Create `.neuron` directory if missing

### DIFF
--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.6.2.0
+version: 0.6.2.1
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src/app/Neuron/Web/Cache.hs
+++ b/neuron/src/app/Neuron/Web/Cache.hs
@@ -26,13 +26,9 @@ type CacheData = (ZettelGraph, Map ZettelID ZettelError)
 
 cacheFile :: Action FilePath
 cacheFile = do
-    ribDir <- ribInputDir
-
-    let neuronDir = ribDir </> ".neuron"
-
-    liftIO (createDirectoryIfMissing True neuronDir)
-
-    pure (neuronDir </> "cache.json")
+  neuronDir <- (</> ".neuron") <$> ribInputDir
+  liftIO $ createDirectoryIfMissing True neuronDir
+  pure $ neuronDir </> "cache.json"
 
 updateCache :: CacheData -> Action ()
 updateCache v = do

--- a/neuron/src/app/Neuron/Web/Cache.hs
+++ b/neuron/src/app/Neuron/Web/Cache.hs
@@ -14,6 +14,7 @@ import Neuron.Zettelkasten.ID (ZettelID)
 import Neuron.Zettelkasten.Zettel (ZettelError)
 import Relude
 import Rib.Shake
+import System.Directory (createDirectoryIfMissing)
 import System.FilePath
 
 data ReadMode
@@ -24,7 +25,14 @@ data ReadMode
 type CacheData = (ZettelGraph, Map ZettelID ZettelError)
 
 cacheFile :: Action FilePath
-cacheFile = (</> ".neuron/cache.json") <$> ribInputDir
+cacheFile = do
+    ribDir <- ribInputDir
+
+    let neuronDir = ribDir </> ".neuron"
+
+    liftIO (createDirectoryIfMissing True neuronDir)
+
+    pure (neuronDir </> "cache.json")
 
 updateCache :: CacheData -> Action ()
 updateCache v = do


### PR DESCRIPTION
… otherwise `neuron new` fails with this error message on first-time setup:

```
[Rib] Unhandled exception when building <unknown>: Error when running Shake build system:
  at action, called at src/Development/Shake/Forward.hs:123:5 in shake-0.19.1-9t93in5US46FSh4fNQCGA:Development.Shake.Forward
* Raised the exception:
./.neuron/cache.json: openBinaryFile: does not exist (No such file or directory)
```