### PR TITLE
Fix MathJax multi-line example

### DIFF
--- a/guide/2013701.md
+++ b/guide/2013701.md
@@ -11,10 +11,10 @@ You can type LaTeX code in zettels in three ways:
 * **Multi-line block, centered**: 
 ```markdown
 $$    
-\begin{equation}
-    x+1 = 2 \\
-    y+2 = 3 
-\end{equation}
+\begin{split}
+    x+1 &= 2 \\
+    y+2 &= 3 
+\end{split}
 $$
 ```
 
@@ -26,8 +26,8 @@ $$
 
 * The multi-line block example shown above will render like this:
 $$    
-\begin{equation}
-    x+1 = 2 \\
-    y+2 = 3 
-\end{equation}
+\begin{split}
+    x+1 &= 2 \\
+    y+2 &= 3 
+\end{split}
 $$


### PR DESCRIPTION
The multi-line example renders in a single line. 
![Screenshot 2020-08-10 at 9 48 20 PM](https://user-images.githubusercontent.com/47273164/89789095-bb09bc00-db52-11ea-9d69-ded7d7903e6e.png)

The proposed fix renders it correctly.
![Screenshot 2020-08-10 at 9 48 00 PM](https://user-images.githubusercontent.com/47273164/89789110-bfce7000-db52-11ea-8a9f-44c6210c527f.png)