### PR TITLE
Support fancy lists (ordered list attributes)

### DIFF
--- a/neuron/src/lib/Neuron/Reader/Markdown.hs
+++ b/neuron/src/lib/Neuron/Reader/Markdown.hs
@@ -108,6 +108,7 @@ neuronSpec =
     [ wrappedLinkSpec angleBracketLinkP,
       wrappedLinkSpec wikiLinkP,
       gfmExtensionsSansEmoji,
+      CE.fancyListSpec,
       CE.footnoteSpec,
       CE.mathSpec,
       CE.smartPunctuationSpec,


### PR DESCRIPTION
This enables full support for [fancy lists](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/fancy_lists.md) in neuron (on the backend). Requires the [identically named PR](https://github.com/srid/reflex-dom-pandoc/pull/7
) in srid/reflex-dom-pandoc in order to actually take advantage of this; otherwise the markdown AST won't be transformed into the correct HTML.