### PR TITLE
Autodetect thunks vs unpacked obelisk dependencies to simplify development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,6 @@ ob thunk unpack dep/reflex-dom-pandoc
 cd dep/reflex-dom-pandoc
 ```
 
-For `nix-build` and `nix-shell` to still work while a dependency is unpacked, you need to change the source patch in `project.nix` to e.g. `reflex-dom-pandoc = ./dep/reflex-dom-pandoc`.
-
 Then you can try your changes with
 ```
 # Run ghcid (using neuron's nix config)
@@ -61,13 +59,11 @@ ob thunk pack dep/reflex-dom-pandoc
 git add dep/reflex-dom-pandoc
 ```
 
-Don‘t forget to revert the temporary changes to your `project.nix`.
-
 ## Guidelines when submitting a PR
 
 ### Autoformatting
 
-Run the `bin/format` script to auto-format your Haskell source changes using [ormolu](https://github.com/tweag/ormolu). 
+Run the `bin/format` script to auto-format your Haskell source changes using [ormolu](https://github.com/tweag/ormolu).
 
 ### Test your build
 

--- a/project.nix
+++ b/project.nix
@@ -23,11 +23,15 @@ let
 
   inherit (import (gitignoreSrc) { inherit (pkgs) lib; }) gitignoreSource;
 
+  thunkOrPath = dep:
+    let p = ./dep + "/${dep}/thunk.nix";
+    in if builtins.pathExists p then import p else (./dep + "/${dep}");
+
   sources = {
     neuron = gitignoreSource ./neuron;
-    rib = import ./dep/rib/thunk.nix;
-    commonmark = import ./dep/commonmark-hs/thunk.nix;
-    reflex-dom-pandoc = import ./dep/reflex-dom-pandoc/thunk.nix;
+    rib = thunkOrPath "rib";
+    commonmark = thunkOrPath "commonmark-hs";
+    reflex-dom-pandoc = thunkOrPath "reflex-dom-pandoc";
   };
 
   searchBuilder = ''


### PR DESCRIPTION
It bugged me to have to remember to pack/unpack, and edit the project.nix file. So now you don't have to edit the project.nix file after unpacking any of the obelisk dependencies.

Opted for the simplest possible thing rather than trying to get fancy with throwing an error message if someone manages to mess things up somehow. Ideally, if this is merged there shouldn't be any reason to even look at the project.nix file (for most simple contributions)