### PR TITLE
Bump nixpkgs and clean-up default.nix

### DIFF
--- a/dep/commonmark-hs/default.nix
+++ b/dep/commonmark-hs/default.nix
@@ -1,2 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import (import ./thunk.nix)

--- a/dep/commonmark-hs/github.json
+++ b/dep/commonmark-hs/github.json
@@ -1,8 +1,0 @@
-{
-  "owner": "jgm",
-  "repo": "commonmark-hs",
-  "branch": "master",
-  "private": false,
-  "rev": "f9132b7686de276454a5aab14df9cabed817f86e",
-  "sha256": "0cx956d9n4lnincv0br6qsgv0vv73ymj3qc5zqqcmhdird36kvm8"
-}

--- a/dep/commonmark-hs/thunk.nix
+++ b/dep/commonmark-hs/thunk.nix
@@ -1,9 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-  json = builtins.fromJSON (builtins.readFile ./github.json);
-in fetch json

--- a/project.nix
+++ b/project.nix
@@ -1,7 +1,7 @@
-let 
+let
   nixpkgsSrc = builtins.fetchTarball {
-    url = "https://github.com/nixos/nixpkgs/archive/5e7fb7699c84.tar.gz";
-    sha256 = "12rqn4a88maggk1vhhfi2vn2j0vf543qnv2zby922mnnrij476gw";
+    url = "https://github.com/nixos/nixpkgs/archive/729e7295cf7b.tar.gz";
+    sha256 = "0mxhi0lc11aa3r7i7din1q2rjg5c4amq3alcr8ga2fcb64vn2zd3";
   };
   gitignoreSrc = builtins.fetchTarball {
     url = "https://github.com/hercules-ci/gitignore/archive/c4662e6.tar.gz";
@@ -30,7 +30,6 @@ let
   sources = {
     neuron = gitignoreSource ./neuron;
     rib = thunkOrPath "rib";
-    commonmark = thunkOrPath "commonmark-hs";
     reflex-dom-pandoc = thunkOrPath "reflex-dom-pandoc";
   };
 
@@ -50,18 +49,8 @@ let
   };
 
   haskellOverrides = self: super: {
-    # We include rib because it is quite tightly coupled with neuron development
     rib-core = self.callCabal2nix "rib-core" (sources.rib + "/rib-core") { };
 
-    # commonmark is not released on hackage yet
-    commonmark =
-      self.callCabal2nix "commonmark" (sources.commonmark + "/commonmark") { };
-    commonmark-extensions = self.callCabal2nix "commonmark-extensions"
-      (sources.commonmark + "/commonmark-extensions") { };
-    commonmark-pandoc = self.callCabal2nix "commonmark-pandoc"
-      (sources.commonmark + "/commonmark-pandoc") { };
-
-    # Also not released yet
     reflex-dom-pandoc =
       pkgs.haskell.lib.dontHaddock (self.callCabal2nix "reflex-dom-pandoc" sources.reflex-dom-pandoc { });
 
@@ -77,7 +66,7 @@ let
       pkg = "skylighting-core";
       ver = "0.9";
       sha256 = "1fb3j5kmfdycxwr7vjdg1hrdz6s61ckp489qj3899klk18pcmpnh";
-    } {}; 
+    } {};
     # Jailbreak to allow newer skylighting. Next version of pandoc shouldn't
     # require this.
     pandoc = doJailbreak super.pandoc_2_10_1;


### PR DESCRIPTION
Removes manual commonmark references because we don‘t need it with newer
nixpkgs