### PR TITLE
Wiki-style links

### DIFF
--- a/guide/2011502.md
+++ b/guide/2011502.md
@@ -5,7 +5,7 @@ tags:
 
 # Tutorial
 
-Make sure you have already installed neuron (see <2011501?cf>). Then follow this tutorial to get your own Zettelkasten up and running.
+Make sure you have already installed neuron (see [[2011501]]). Then follow this tutorial to get your own Zettelkasten up and running.
 
 ## Test with an existing Zettelkasten
 

--- a/guide/2011506.md
+++ b/guide/2011506.md
@@ -9,18 +9,18 @@ example, to link to a list of a zettels with the "science" tag (from the example
 at <2011505?cf>):
 
 ```markdown
-<z:zettels?tag=science&timeline>
+[[z:zettels?tag=science&timeline]]
 ```
 
 You can use the CLI to see which zettels will be included in a given query; see
-<2013501?cf>.
+[[2013501]].
 
 ### Example
 
 As an example here is a list of zettels tagged "walkthrough" on this very
 Zettelkasten:
 
-<z:zettels?tag=walkthrough&cf>
+[[z:zettels?tag=walkthrough]]
 
 It was created by `<z:zettels?tag=walkthrough&cf>`. Note that here we
 use the `cf` flag to not affect the <2017401?cf> of the graph; whereas without

--- a/guide/index.md
+++ b/guide/index.md
@@ -2,14 +2,14 @@
 
 ![Neuron logo](https://raw.githubusercontent.com/srid/neuron/master/assets/neuron.svg){.ui .tiny .right .floated .image}
 
-[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your plain-text notes in <2011401> style, as well as for publishing them on the web. Read its <6f0f0bcc>.
+[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your plain-text notes in [[[2011401]]] style, as well as for publishing them on the web. Read its [[[6f0f0bcc]]].
 
 ## Getting started
 
-* <2011501>
-* <2011502>
-* <2011402>
-* <2013101>
+* [[[2011501]]]
+* [[[2011502]]]
+* [[[2011402]]]
+* [[[2013101]]]
 
 ## External links
 
@@ -18,4 +18,4 @@
 * [Project Discussion Chat](https://github.com/srid/neuron#discussion)
 * [Sponsor the project](https://github.com/sponsors/srid)
 
-[^web]: For a web interface to your neuron notes, see <041726b3>
+[^web]: For a web interface to your neuron notes, see [[[041726b3]]]


### PR DESCRIPTION
Part of #312

Replace autolinks with Wiki links (see below), making them the default. Autolinks will be supported for backwards compat.

- `<foo?cf>` replaced by `[[foo]]`
- `<foo>` replaced by `[[[foo]]]` 
- `<z:zettels?tag=xyz>` replaced by `[[[z:zettels?tag=xyz]]]`

In particular note that `[[[...]]]` makes the link a folgezettel, whereas `[[..]]` makes it a cf. This applies to full URI queries too.

The following are outside the scope of this PR:

- `{{..}}` style links
- Plain markdown links

Tasks,

- [x] Working prototype
- [ ] Complete, and refactor, implementation
- [ ] Add unit test coversage
- [ ] Replace all links in ./guide, and update documentation