### PR TITLE
Support regular Markdown links

### DIFF
--- a/dep/reflex-dom-pandoc/github.json
+++ b/dep/reflex-dom-pandoc/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "srid",
   "repo": "reflex-dom-pandoc",
-  "branch": "link-inner",
+  "branch": "master",
   "private": false,
-  "rev": "87486d7b705a85951846c2ee2829ffbb92f290ef",
+  "rev": "259c7a881dd4ba69f82ac2fdec83ddf8f5ee0fc5",
   "sha256": "098cdg2yyk62wk4pmqivvibi2yd90rywlzz0a7gfixgki94sshq3"
 }

--- a/dep/reflex-dom-pandoc/github.json
+++ b/dep/reflex-dom-pandoc/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "srid",
   "repo": "reflex-dom-pandoc",
-  "branch": "master",
+  "branch": "link-inner",
   "private": false,
-  "rev": "5b600a23dd12404976a476d262a6f97544e4d829",
-  "sha256": "12r5ygdp3b6d72i3xfly3h7lcczwqwajynf628k9pip7fm2c7d5w"
+  "rev": "87486d7b705a85951846c2ee2829ffbb92f290ef",
+  "sha256": "098cdg2yyk62wk4pmqivvibi2yd90rywlzz0a7gfixgki94sshq3"
 }

--- a/guide/2011504.md
+++ b/guide/2011504.md
@@ -1,6 +1,24 @@
 # Linking
 
-To link to another zettel, put the [[2011403]] inside `[[[..]]]` or `[[..]]`[^autolink]:
+To link to another zettel, you can use regular Markdown links, or use the
+special Wiki-link syntax by putting the [[2011403]] inside `[[..]]`[^autolink]:
+
+```
+This is a zettel file, which links to another zettel:
+
+* [[ef3dke98]]
+
+You can also use regular Markdown links:
+
+* [My zettel](ef3dke98.md)
+```
+
+In [[2011405]], neuron will automatically display the title of the
+linked zettel when using the wiki-link syntax.
+
+## Branching links
+
+Neuron supports branching links, which can be created using `[[[..]]]`:
 
 ```
 This is a zettel file, which links (branches of) to another zettel:
@@ -13,24 +31,8 @@ specified zettel. When a zettel has a folgezettel relationship to another
 zettel, it is said to "branch of" to the other zettel. Folgezetel relationships
 define the [[2017401]] of your zettel graph. 
 
-In [[2011405]], neuron will automatically display the title of the
-linked zettel.
-
-## Non-branching links
-
-If your link is merely a reference to another zettel, and you do not wish it to
-be part of the [[2017401]] and the linked zettel's [[5e41fd32]], use the
-2-bracket syntax: (eg: `[[ef3dke98]]`). 
-
-```
-This is a zettel file, which refers to another zettel without 
-branching to it:
-
-* [[ef3dke98]]
-```
-
-Neuron will link the zettels, but the link would be ignored from [[2017401]]
-as well as the [[5e41fd32]] of the zettel.
+Branching links affect the linked zettel's [[5e41fd32]] where the linking
+zettel is displayed.
 
 ## Advanced linking
 

--- a/guide/2017401.md
+++ b/guide/2017401.md
@@ -1,10 +1,15 @@
 # Folgezettel Heterarchy
 
-Neuron allows you to organically build a [[2011407]] out of your Zettelkasten over time. When a zettel links (see [[2011504]]) to another, it "branches off"[^folge] to that zettel ... using `[[[...]]]` (i.e, three brackets, instead of two).
+Neuron allows you to organically build a [[2011407]] out of your Zettelkasten
+over time. When a zettel links (see [[2011504]]) to another, it "branches
+off"[^folge] to that zettel ... using `[[[...]]]` (i.e, three brackets, instead
+of two).
 
-A folgezettel heterarchy differs from a traditional "category tree" in two key ways:
+A folgezettel heterarchy differs from a traditional "category tree" in two key
+ways:
 
-* It is built *organically* over time based on the connections formed, instead of being pre-defined.
+* It is built *organically* over time based on the connections formed, instead
+  of being pre-defined.
 * A note can have *multiple* parents.
 
 The heterarchy is displayed in the following places

--- a/guide/5e41fd32.md
+++ b/guide/5e41fd32.md
@@ -4,6 +4,8 @@ date: 2020-07-24
 
 # Uplink Tree
 
-An **uplink tree** of a zettel is the subset of the [[2017401]] which branch off to the zettel. Uplink tree is displayed above the zettel; other backlinks are displayed below.
+An **uplink tree** of a zettel is the subset of the [[2017401]] which branch
+off to the zettel. Uplink tree is displayed above the zettel; other backlinks
+are displayed below.
 
 Link using `[[...]]` (see [[2011504]]) to eject something out of a zettel's uplink tree.

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -61,7 +61,7 @@ common library-common
     data-default,
     reflex,
     reflex-dom-core,
-    reflex-dom-pandoc >= 0.2.4.0,
+    reflex-dom-pandoc >= 0.2.5.0,
     clay,
     tagged
 

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -33,7 +33,7 @@ import Data.Time.DateMayTime
 import Neuron.Reader.Type (ZettelFormat)
 import qualified Neuron.Web.Route as R
 import qualified Neuron.Zettelkasten.Connection as C
-import Neuron.Zettelkasten.ID (ZettelID, parseZettelID')
+import Neuron.Zettelkasten.ID (ZettelID, parseZettelID)
 import Neuron.Zettelkasten.ID.Scheme (IDScheme (..))
 import qualified Neuron.Zettelkasten.Query.Error as Q
 import Neuron.Zettelkasten.Query.Graph as Q
@@ -224,7 +224,7 @@ commandParser defaultNotesDir now = do
       pure RibConfig {..}
     zettelIDReader :: ReadM ZettelID
     zettelIDReader =
-      eitherReader $ first show . parseZettelID' . toText
+      eitherReader $ first show . parseZettelID . toText
     queryReader :: ReadM (Some Q.ZettelQuery)
     queryReader =
       eitherReader $ \(toText -> s) -> case URI.mkURI s of

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -164,15 +164,16 @@ commandParser defaultNotesDir now = do
             (OpenCommand . Some . R.Route_Zettel)
             (option zettelIDReader (long "id" <> help "Open the zettel HTML page" <> metavar "ID"))
     queryCommand = do
+      let connDontCare = C.OrdinaryConnection -- Don't care about connections in CLI
       cached <- switch (long "cached" <> help "Use cached zettelkasten graph (faster)")
       query <-
         fmap
           Left
           ( fmap
-              (Some . flip Q.ZettelQuery_ZettelByID def)
+              (Some . flip Q.ZettelQuery_ZettelByID connDontCare)
               (option zettelIDReader (long "id"))
               <|> fmap
-                (\x -> Some $ Q.ZettelQuery_ZettelsByTag x def def)
+                (\x -> Some $ Q.ZettelQuery_ZettelsByTag x connDontCare def)
                 (many (mkTagPattern <$> option str (long "tag" <> short 't')))
               <|> option queryReader (long "uri" <> short 'u')
           )

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -169,10 +169,10 @@ commandParser defaultNotesDir now = do
         fmap
           Left
           ( fmap
-              (Some . flip Q.ZettelQuery_ZettelByID Nothing)
+              (Some . flip Q.ZettelQuery_ZettelByID def)
               (option zettelIDReader (long "id"))
               <|> fmap
-                (\x -> Some $ Q.ZettelQuery_ZettelsByTag x Nothing def)
+                (\x -> Some $ Q.ZettelQuery_ZettelsByTag x def def)
                 (many (mkTagPattern <$> option str (long "tag" <> short 't')))
               <|> option queryReader (long "uri" <> short 'u')
           )

--- a/neuron/src/app/Neuron/Config/Alias.hs
+++ b/neuron/src/app/Neuron/Config/Alias.hs
@@ -32,7 +32,7 @@ getAliases Config {..} graph = do
       pure v
   where
     hasIndexZettel =
-      isJust . G.getZettel (parseZettelID "index")
+      isJust . G.getZettel (ZettelCustomID "index")
 
 mkAliases :: [Text] -> ZettelGraph -> Either Text [Alias]
 mkAliases aliasSpecs graph =

--- a/neuron/src/app/Neuron/Web/Generate.hs
+++ b/neuron/src/app/Neuron/Web/Generate.hs
@@ -151,7 +151,7 @@ loadZettelkastenFrom fs = do
       flip runStateT Map.empty $ do
         forM_ fs $ \(format, files) -> do
           forM_ files $ \relPath -> do
-            case getZettelID relPath of
+            case getZettelID format relPath of
               Nothing ->
                 pure ()
               Just zid -> do

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -41,9 +41,9 @@ import Text.Pandoc.Definition (Inline)
 renderQueryResult ::
   PandocBuilder t m => Maybe [Inline] -> DSum ZettelQuery Identity -> NeuronWebT t m ()
 renderQueryResult minner = \case
-  ZettelQuery_ZettelByID _zid (fromMaybe def -> conn) :=> Identity target -> do
+  ZettelQuery_ZettelByID _zid conn :=> Identity target -> do
     renderZettelLink (elPandocInlines <$> minner) (Just conn) Nothing target
-  q@(ZettelQuery_ZettelsByTag pats (fromMaybe def -> conn) view) :=> Identity res -> do
+  q@(ZettelQuery_ZettelsByTag pats conn view) :=> Identity res -> do
     el "section" $ do
       renderQuery $ Some q
       case zettelsViewGroupByTag view of

--- a/neuron/src/lib/Neuron/Web/Query/View.hs
+++ b/neuron/src/lib/Neuron/Web/Query/View.hs
@@ -121,10 +121,6 @@ renderZettelLink mInner conn (fromMaybe def -> linkView) Zettel {..} = do
         -- The extra space is so that double clicking on this extra text
         -- doesn't select the title next.
         text " "
-    let linkTooltip =
-          if null zettelTags
-            then Nothing
-            else Just $ "Tags: " <> T.intercalate "; " (unTag <$> zettelTags)
     elAttr "span" ("class" =: "zettel-link" <> withTooltip linkTooltip) $ do
       let linkInnerHtml = fromMaybe (text zettelTitle) mInner
       neuronRouteLink (Some $ Route_Zettel zettelID) mempty linkInnerHtml
@@ -133,6 +129,15 @@ renderZettelLink mInner conn (fromMaybe def -> linkView) Zettel {..} = do
           elAttr "sup" ("title" =: "Branching link (folgezettel)") $ text "ᛦ"
         _ -> pure mempty
   where
+    linkTooltip =
+      -- If there is custom inner text, put zettel title in tooltip.
+      -- Otherwise put tags if any.
+      if isJust mInner
+        then Just $ "Zettel: " <> zettelTitle
+        else
+          if null zettelTags
+            then Nothing
+            else Just $ "Tags: " <> T.intercalate "; " (unTag <$> zettelTags)
     -- Prevent this element from appearing in Google search results
     -- https://developers.google.com/search/reference/robots_meta_tag#data-nosnippet-attr
     elNoSnippetSpan :: DomBuilder t m => Map Text Text -> NeuronWebT t m a -> NeuronWebT t m a

--- a/neuron/src/lib/Neuron/Web/ZIndex.hs
+++ b/neuron/src/lib/Neuron/Web/ZIndex.hs
@@ -94,7 +94,7 @@ renderZIndex (Theme.semanticColor -> themeColor) ZIndex {..} = do
       divClass "ui message pinned raised segment" $ do
         el "ul" $
           forM_ zs $ \z ->
-            el "li" $ QueryView.renderZettelLink Nothing def z
+            el "li" $ QueryView.renderZettelLink Nothing Nothing def z
     forM_ zIndexClusters $ \forest ->
       divClass ("ui " <> themeColor <> " segment") $ do
         el "ul" $ renderForest forest
@@ -146,7 +146,7 @@ renderForest ::
 renderForest trees = do
   forM_ trees $ \(Node (zettel, uplinks) subtrees) ->
     el "li" $ do
-      QueryView.renderZettelLink Nothing def zettel
+      QueryView.renderZettelLink Nothing Nothing def zettel
       when (length uplinks >= 2) $ do
         elClass "span" "uplinks" $ do
           forM_ uplinks $ \z2 -> do

--- a/neuron/src/lib/Neuron/Web/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Web/Zettel/View.hs
@@ -92,7 +92,7 @@ evalAndRenderZettelQuery ::
   NeuronWebT t m [QueryError] ->
   URILink ->
   NeuronWebT t m [QueryError]
-evalAndRenderZettelQuery graph oldRender uriLink@(URILink inner _uri isAutoLink) = do
+evalAndRenderZettelQuery graph oldRender uriLink@(URILink inner _uri) = do
   case flip runReaderT (G.getZettels graph) (Q.runQueryURILink uriLink) of
     Left e -> do
       -- Error parsing or running the query.
@@ -101,9 +101,7 @@ evalAndRenderZettelQuery graph oldRender uriLink@(URILink inner _uri isAutoLink)
       -- This is not a query link; pass through.
       oldRender
     Right (Just res) -> do
-      -- Discard link inner only if it is an autolink
-      let mLinkInner = if isAutoLink then Nothing else Just inner
-      Q.renderQueryResult mLinkInner res
+      Q.renderQueryResult inner res
       pure mempty
   where
     elInlineError e =

--- a/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
@@ -7,8 +7,6 @@
 module Neuron.Zettelkasten.Connection where
 
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Default
-import Reflex.Dom.Pandoc (URILink (..))
 import Relude hiding (show)
 import Text.Show
 
@@ -27,17 +25,7 @@ instance Semigroup Connection where
   _ <> Folgezettel = Folgezettel
   OrdinaryConnection <> OrdinaryConnection = OrdinaryConnection
 
-instance Default Connection where
-  def = Folgezettel
-
 instance Show Connection where
   show = \case
     Folgezettel -> "folgezettel"
     OrdinaryConnection -> "cf"
-
-defaultConnection :: URILink -> Connection
-defaultConnection URILink {..} =
-  if isNothing _uriLink_inner
-    then Folgezettel -- Autolinks
-    -- NOTE: This will need to be changed when we implement `[[foo | some text]]`
-    else OrdinaryConnection

--- a/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Zettelkasten.Connection where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Default
+import Reflex.Dom.Pandoc (URILink (..))
 import Relude hiding (show)
 import Text.Show
 
@@ -32,3 +34,10 @@ instance Show Connection where
   show = \case
     Folgezettel -> "folgezettel"
     OrdinaryConnection -> "cf"
+
+defaultConnection :: URILink -> Connection
+defaultConnection URILink {..} =
+  if isNothing _uriLink_inner
+    then Folgezettel -- Autolinks
+    -- NOTE: This will need to be changed when we implement `[[foo | some text]]`
+    else OrdinaryConnection

--- a/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Connection.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.Zettelkasten.Connection where

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
@@ -97,9 +97,14 @@ getZettels = G.getVertices
 getZettel :: ZettelID -> ZettelGraph -> Maybe Zettel
 getZettel = G.findVertex
 
--- | If no connection exists, this returns Nothing.
+-- | Return the connection if any between two zettels
+--
+-- If no connection exists, this returns Nothing.
 getConnection :: Zettel -> Zettel -> ZettelGraph -> Maybe Connection
-getConnection z1 z2 g = join $ G.edgeLabel g z1 z2
+getConnection z1 z2 g =
+  -- Use `join` so that empty edge monoid is treated as an abscence of edge
+  -- (connection)
+  join $ G.edgeLabel g z1 z2
 
 connectionCount :: ZettelGraph -> Int
 connectionCount = LAM.edgeCount . G.getGraph

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph.hs
@@ -24,7 +24,6 @@ module Neuron.Zettelkasten.Graph
 where
 
 import qualified Algebra.Graph.Labelled.AdjacencyMap as LAM
-import Data.Default
 import Data.Foldable (maximum)
 import qualified Data.Graph.Labelled as G
 import qualified Data.Set as Set
@@ -100,7 +99,7 @@ getZettel = G.findVertex
 
 -- | If no connection exists, this returns Nothing.
 getConnection :: Zettel -> Zettel -> ZettelGraph -> Maybe Connection
-getConnection z1 z2 g = fmap (fromMaybe def) $ G.edgeLabel g z1 z2
+getConnection z1 z2 g = join $ G.edgeLabel g z1 z2
 
 connectionCount :: ZettelGraph -> Int
 connectionCount = LAM.edgeCount . G.getGraph

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
@@ -67,6 +67,7 @@ runQueryConnections zettels z =
 
 edgeFromConnection :: Zettel -> (Maybe Connection, Zettel) -> (Maybe Connection, Zettel, Zettel)
 edgeFromConnection z (c, z2) =
+  -- hardcoded deffault, wtf
   (connectionMonoid $ fromMaybe Folgezettel c, z, z2)
   where
     -- Our connection monoid will never be Nothing (mempty); see the note in

--- a/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Graph/Build.hs
@@ -49,7 +49,7 @@ mkZettelGraph ::
     Map ZettelID (NonEmpty QueryError)
   )
 mkZettelGraph zettels =
-  let res :: [(Zettel, ([(Maybe Connection, Zettel)], [QueryError]))] =
+  let res :: [(Zettel, ([(Connection, Zettel)], [QueryError]))] =
         flip fmap zettels $ \z ->
           (z, runQueryConnections zettels z)
       g :: ZettelGraph = G.mkGraphFrom zettels $
@@ -60,15 +60,14 @@ mkZettelGraph zettels =
           (zettelID z,) <$> merrs
    in (g, errors)
 
-runQueryConnections :: [Zettel] -> Zettel -> ([(Maybe Connection, Zettel)], [QueryError])
+runQueryConnections :: [Zettel] -> Zettel -> ([(Connection, Zettel)], [QueryError])
 runQueryConnections zettels z =
   flip runReader zettels $ do
     runWriterT $ queryConnections z
 
-edgeFromConnection :: Zettel -> (Maybe Connection, Zettel) -> (Maybe Connection, Zettel, Zettel)
+edgeFromConnection :: Zettel -> (Connection, Zettel) -> (Maybe Connection, Zettel, Zettel)
 edgeFromConnection z (c, z2) =
-  -- hardcoded deffault, wtf
-  (connectionMonoid $ fromMaybe Folgezettel c, z, z2)
+  (connectionMonoid c, z, z2)
   where
     -- Our connection monoid will never be Nothing (mempty); see the note in
     -- type `ZettelGraph`.

--- a/neuron/src/lib/Neuron/Zettelkasten/ID.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/ID.hs
@@ -123,7 +123,8 @@ customIDParser = do
   fmap toText $ M.some $ M.alphaNumChar <|> M.char '_' <|> M.char '-'
 
 -- | Parse the ZettelID if the given filepath is a zettel.
-getZettelID :: FilePath -> Maybe ZettelID
-getZettelID fp =
-  let (name, _) = splitExtension $ takeFileName fp
-   in rightToMaybe $ parseZettelID' $ toText name
+getZettelID :: ZettelFormat -> FilePath -> Maybe ZettelID
+getZettelID fmt fp = do
+  let (name, ext) = splitExtension $ takeFileName fp
+  guard $ zettelFormatToExtension fmt == toText ext
+  rightToMaybe $ parseZettelID' $ toText name

--- a/neuron/src/lib/Neuron/Zettelkasten/ID.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/ID.hs
@@ -11,7 +11,6 @@ module Neuron.Zettelkasten.ID
   ( ZettelID (..),
     InvalidID (..),
     zettelIDText,
-    parseZettelID,
     parseZettelID',
     idParser,
     getZettelID,
@@ -91,10 +90,6 @@ zettelIDSourceFileName zid fmt = toString $ zettelIDText zid <> zettelFormatToEx
 
 data InvalidID = InvalidIDParseError Text
   deriving (Eq, Generic, ToJSON, FromJSON)
-
-parseZettelID :: HasCallStack => Text -> ZettelID
-parseZettelID =
-  either (error . show) id . parseZettelID'
 
 parseZettelID' :: Text -> Either InvalidID ZettelID
 parseZettelID' =

--- a/neuron/src/lib/Neuron/Zettelkasten/ID.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/ID.hs
@@ -11,7 +11,7 @@ module Neuron.Zettelkasten.ID
   ( ZettelID (..),
     InvalidID (..),
     zettelIDText,
-    parseZettelID',
+    parseZettelID,
     idParser,
     getZettelID,
     zettelIDSourceFileName,
@@ -46,7 +46,7 @@ instance Show InvalidID where
 instance FromJSON ZettelID where
   parseJSON x = do
     s <- parseJSON x
-    case parseZettelID' s of
+    case parseZettelID s of
       Left e -> fail $ show e
       Right zid -> pure zid
 
@@ -55,7 +55,7 @@ instance ToJSONKey ZettelID where
 
 instance FromJSONKey ZettelID where
   fromJSONKey = FromJSONKeyTextParser $ \s ->
-    case parseZettelID' s of
+    case parseZettelID s of
       Right v -> pure v
       Left e -> fail $ show e
 
@@ -91,8 +91,8 @@ zettelIDSourceFileName zid fmt = toString $ zettelIDText zid <> zettelFormatToEx
 data InvalidID = InvalidIDParseError Text
   deriving (Eq, Generic, ToJSON, FromJSON)
 
-parseZettelID' :: Text -> Either InvalidID ZettelID
-parseZettelID' =
+parseZettelID :: Text -> Either InvalidID ZettelID
+parseZettelID =
   first InvalidIDParseError . parse idParser "parseZettelID"
 
 idParser :: Parser ZettelID
@@ -127,4 +127,4 @@ getZettelID :: ZettelFormat -> FilePath -> Maybe ZettelID
 getZettelID fmt fp = do
   let (name, ext) = splitExtension $ takeFileName fp
   guard $ zettelFormatToExtension fmt == toText ext
-  rightToMaybe $ parseZettelID' $ toText name
+  rightToMaybe $ parseZettelID $ toText name

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Eval.hs
@@ -53,7 +53,7 @@ queryConnections ::
     MonadReader [Zettel] m
   ) =>
   Zettel ->
-  m [(Maybe Connection, Zettel)]
+  m [(Connection, Zettel)]
 queryConnections Zettel {..} = do
   -- Report any query parse errors
   case zettelError of
@@ -70,12 +70,12 @@ queryConnections Zettel {..} = do
         Right res ->
           pure $ getConnections res
   where
-    getConnections :: DSum ZettelQuery Identity -> [(Maybe Connection, Zettel)]
+    getConnections :: DSum ZettelQuery Identity -> [(Connection, Zettel)]
     getConnections = \case
-      ZettelQuery_ZettelByID _ mconn :=> Identity res ->
-        [(mconn, res)]
-      ZettelQuery_ZettelsByTag _ mconn _mview :=> Identity res ->
-        (mconn,) <$> res
+      ZettelQuery_ZettelByID _ conn :=> Identity res ->
+        [(conn, res)]
+      ZettelQuery_ZettelsByTag _ conn _mview :=> Identity res ->
+        (conn,) <$> res
       ZettelQuery_Tags _ :=> _ ->
         mempty
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -22,6 +22,7 @@ where
 import Control.Monad.Except
 import Data.Some
 import Data.TagTree (TagPattern, mkTagPattern)
+import Neuron.Reader.Type (ZettelFormat (..))
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Error
@@ -62,7 +63,7 @@ parseLinkURI isAutoLink uri = do
       -- Look for short links, eg: `<foo-bar>`
       Nothing -> do
         (URI.unRText -> path) :| [] <- hoistMaybe $ fmap snd (URI.uriPath uri)
-        zid <- hoistMaybe $ rightToMaybe $ parseZettelID' path
+        zid <- hoistMaybe $ rightToMaybe (parseZettelID' path) <|> getZettelID ZettelFormat_Markdown (toString path)
         pure $ Some $ ZettelQuery_ZettelByID zid conn
       Just (URI.unRText -> proto) -> do
         guard $ proto == "z"

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -38,7 +38,7 @@ import Text.URI.Util (getQueryParam, hasQueryFlag)
 -- | Parse a query if any from a Markdown link
 queryFromURILink :: MonadError QueryParseError m => URILink -> m (Maybe (Some ZettelQuery))
 queryFromURILink l@URILink {..} =
-  queryFromURI' (defaultConnection l) _uriLink_uri
+  queryFromURI (defaultConnection l) _uriLink_uri
   where
     -- The default connection to use if the user has not explicitly specified
     -- one in the query URI.
@@ -50,18 +50,8 @@ queryFromURILink l@URILink {..} =
         else OrdinaryConnection
 
 -- | Parse a query from the given URI.
---
--- This function is used only in the CLI. For handling links in a Markdown file,
--- your want `queryFromURILink` which allows specifying the link text as well.
-queryFromURI :: MonadError QueryParseError m => URI -> m (Maybe (Some ZettelQuery))
-queryFromURI =
-  queryFromURI' conn
-  where
-    -- The value of this doesn't matter
-    conn = OrdinaryConnection
-
-queryFromURI' :: MonadError QueryParseError m => Connection -> URI -> m (Maybe (Some ZettelQuery))
-queryFromURI' defConn uri = do
+queryFromURI :: MonadError QueryParseError m => Connection -> URI -> m (Maybe (Some ZettelQuery))
+queryFromURI defConn uri = do
   let conn = fromMaybe defConn (queryConn uri)
   liftEither . runMaybeT $ do
     -- Non-relevant parts of the URI should be empty

--- a/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Query/Parser.hs
@@ -36,22 +36,21 @@ import qualified Text.URI as URI
 import Text.URI.QQ (queryKey)
 import Text.URI.Util (getQueryParam, hasQueryFlag)
 
+-- | Parse a query if any from a Markdown link
+queryFromURILink :: MonadError QueryParseError m => URILink -> m (Maybe (Some ZettelQuery))
+queryFromURILink l@URILink {..} =
+  queryFromURI' (defaultConnection l) _uriLink_uri
+
 -- | Parse a query from the given URI.
 --
 -- This function is used only in the CLI. For handling links in a Markdown file,
 -- your want `queryFromURILink` which allows specifying the link text as well.
 queryFromURI :: MonadError QueryParseError m => URI -> m (Maybe (Some ZettelQuery))
 queryFromURI =
-  parseLinkURI def
+  queryFromURI' def
 
-queryFromURILink :: MonadError QueryParseError m => URILink -> m (Maybe (Some ZettelQuery))
-queryFromURILink l@URILink {..} =
-  parseLinkURI (defaultConnection l) _uriLink_uri
-
--- | Parse commonmark autolink style links, eg: `<2014533>`
--- TODO: update doc
-parseLinkURI :: MonadError QueryParseError m => Connection -> URI -> m (Maybe (Some ZettelQuery))
-parseLinkURI defConn uri = do
+queryFromURI' :: MonadError QueryParseError m => Connection -> URI -> m (Maybe (Some ZettelQuery))
+queryFromURI' defConn uri = do
   let conn = fromMaybe defConn (queryConn uri)
   liftEither . runMaybeT $ do
     -- Non-relevant parts of the URI should be empty

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -40,8 +40,8 @@ import Text.Show (Show (show))
 --
 -- It does not care about the relationship *between* those zettels; for that use `GraphQuery`.
 data ZettelQuery r where
-  ZettelQuery_ZettelByID :: ZettelID -> Maybe Connection -> ZettelQuery Zettel
-  ZettelQuery_ZettelsByTag :: [TagPattern] -> Maybe Connection -> ZettelsView -> ZettelQuery [Zettel]
+  ZettelQuery_ZettelByID :: ZettelID -> Connection -> ZettelQuery Zettel
+  ZettelQuery_ZettelsByTag :: [TagPattern] -> Connection -> ZettelsView -> ZettelQuery [Zettel]
   ZettelQuery_Tags :: [TagPattern] -> ZettelQuery (Map Tag Natural)
 
 -- | A zettel note

--- a/neuron/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
@@ -19,7 +19,7 @@ spec = do
     let zettels =
           Set.fromList $
             fmap
-              parseZettelID
+              (either (error . show) id . parseZettelID')
               [ "ribeye-steak",
                 "2015403"
               ]

--- a/neuron/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/ID/SchemeSpec.hs
@@ -19,7 +19,7 @@ spec = do
     let zettels =
           Set.fromList $
             fmap
-              (either (error . show) id . parseZettelID')
+              (either (error . show) id . parseZettelID)
               [ "ribeye-steak",
                 "2015403"
               ]

--- a/neuron/test/Neuron/Zettelkasten/IDSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/IDSpec.hs
@@ -22,14 +22,14 @@ spec = do
       it "parses a zettel ID" $ do
         Z.parseZettelID' "2011401" `shouldBe` Right zid
       it "parses a zettel ID from zettel filename" $ do
-        Z.getZettelID "2011401.md" `shouldBe` Just zid
+        Z.getZettelID Z.ZettelFormat_Markdown "2011401.md" `shouldBe` Just zid
         Z.zettelIDSourceFileName zid Z.ZettelFormat_Markdown `shouldBe` "2011401.md"
     context "custom id parsing" $ do
       let zid = Z.ZettelCustomID "20abcde"
       it "parses a custom zettel ID" $ do
         Z.parseZettelID' "20abcde" `shouldBe` Right zid
       it "parses a custom zettel ID from zettel filename" $ do
-        Z.getZettelID "20abcde.md" `shouldBe` Just zid
+        Z.getZettelID Z.ZettelFormat_Markdown "20abcde.md" `shouldBe` Just zid
         Z.zettelIDSourceFileName zid Z.ZettelFormat_Markdown `shouldBe` "20abcde.md"
       let deceptiveZid = Z.ZettelCustomID "2136537e"
       it "parses a custom zettel ID that looks like date ID" $ do

--- a/neuron/test/Neuron/Zettelkasten/IDSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/IDSpec.hs
@@ -20,7 +20,7 @@ spec = do
     context "date id parsing" $ do
       let zid = Z.ZettelDateID day 1
       it "parses a zettel ID" $ do
-        Z.parseZettelID "2011401" `shouldBe` zid
+        Z.parseZettelID' "2011401" `shouldBe` Right zid
       it "parses a zettel ID from zettel filename" $ do
         Z.getZettelID "2011401.md" `shouldBe` Just zid
         Z.zettelIDSourceFileName zid Z.ZettelFormat_Markdown `shouldBe` "2011401.md"

--- a/neuron/test/Neuron/Zettelkasten/IDSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/IDSpec.hs
@@ -20,20 +20,25 @@ spec = do
     context "date id parsing" $ do
       let zid = Z.ZettelDateID day 1
       it "parses a zettel ID" $ do
-        Z.parseZettelID' "2011401" `shouldBe` Right zid
+        Z.parseZettelID "2011401" `shouldBe` Right zid
       it "parses a zettel ID from zettel filename" $ do
         Z.getZettelID Z.ZettelFormat_Markdown "2011401.md" `shouldBe` Just zid
         Z.zettelIDSourceFileName zid Z.ZettelFormat_Markdown `shouldBe` "2011401.md"
     context "custom id parsing" $ do
       let zid = Z.ZettelCustomID "20abcde"
       it "parses a custom zettel ID" $ do
-        Z.parseZettelID' "20abcde" `shouldBe` Right zid
+        Z.parseZettelID "20abcde" `shouldBe` Right zid
       it "parses a custom zettel ID from zettel filename" $ do
         Z.getZettelID Z.ZettelFormat_Markdown "20abcde.md" `shouldBe` Just zid
         Z.zettelIDSourceFileName zid Z.ZettelFormat_Markdown `shouldBe` "20abcde.md"
       let deceptiveZid = Z.ZettelCustomID "2136537e"
       it "parses a custom zettel ID that looks like date ID" $ do
-        Z.parseZettelID' "2136537e" `shouldBe` Right deceptiveZid
+        Z.parseZettelID "2136537e" `shouldBe` Right deceptiveZid
+    context "failures" $ do
+      it "fails to parse ID with disallowed characters" $ do
+        Z.parseZettelID "/foo" `shouldSatisfy` isLeft
+        Z.parseZettelID "foo." `shouldSatisfy` isLeft
+        Z.parseZettelID "foo bar" `shouldSatisfy` isLeft
   describe "ID converstion" $ do
     context "JSON encoding" $ do
       let day = fromGregorian 2020 3 19

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -57,14 +57,24 @@ spec = do
     it "z:tags?filter=foo" $ do
       queryFromURILink (shortLink "z:tags?filter=foo")
         `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo"])
+  let normalLink = mkURILink "some link text"
   describe "flexible links (regular markdown)" $ do
-    let normalLink = mkURILink "some link text"
     it "Default connection type should be cf" $ do
       queryFromURILink (normalLink "foo-bar")
         `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
     it "Supports full filename instead of zettel ID" $ do
       queryFromURILink (normalLink "foo-bar.md")
         `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
+  describe "non-connection links" $ do
+    it "pass through normal links" $ do
+      queryFromURILink (normalLink "https://www.srid.ca")
+        `shouldBe` Right Nothing
+      queryFromURILink (normalLink "/static/resume.pdf")
+        `shouldBe` Right Nothing
+      queryFromURILink (normalLink "/static/")
+        `shouldBe` Right Nothing
+      queryFromURILink (normalLink "/static")
+        `shouldBe` Right Nothing
 
 mkURILink :: Text -> Text -> URILink
 mkURILink linkText s =

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -13,63 +13,16 @@ import Data.TagTree
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Parser
-import Neuron.Zettelkasten.Query.Theme
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Pandoc.URILink
 import Relude
 import Test.Hspec
+import Text.Pandoc.Definition
 import Text.URI
 
 spec :: Spec
 spec = do
-  legacyLinks
   shortLinks
-
-legacyLinks :: Spec
-legacyLinks = do
-  describe "Parse zettels by tag URIs" $ do
-    for_ [("zquery", Nothing), ("zcfquery", Just OrdinaryConnection)] $ \(scheme, mconn) -> do
-      context scheme $ do
-        let zettelsByTag pat mview =
-              Right $ Just $ Some $ ZettelQuery_ZettelsByTag (fmap mkTagPattern pat) mconn mview
-            withScheme s = toText scheme <> s
-            legacyLink l = mkURILink "." l
-        it "Parse all zettels URI" $ do
-          queryFromURILink (legacyLink $ withScheme "://search")
-            `shouldBe` zettelsByTag [] def
-        it "Parse single tag" $
-          queryFromURILink (legacyLink $ withScheme "://search?tag=foo")
-            `shouldBe` zettelsByTag ["foo"] def
-        it "Parse hierarchical tag" $ do
-          queryFromURILink (legacyLink $ withScheme "://search?tag=foo/bar")
-            `shouldBe` zettelsByTag ["foo/bar"] def
-        it "Parse tag pattern" $ do
-          queryFromURILink (legacyLink $ withScheme "://search?tag=foo/**/bar/*/baz")
-            `shouldBe` zettelsByTag ["foo/**/bar/*/baz"] def
-        it "Parse multiple tags" $
-          queryFromURILink (legacyLink $ withScheme "://search?tag=foo&tag=bar")
-            `shouldBe` zettelsByTag ["foo", "bar"] def
-        it "Handles ?grouped" $ do
-          queryFromURILink (legacyLink $ withScheme "://search?grouped")
-            `shouldBe` zettelsByTag [] (ZettelsView def True)
-        it "Handles ?linkTheme=withDate" $ do
-          queryFromURILink (legacyLink $ withScheme "://search?linkTheme=withDate")
-            `shouldBe` zettelsByTag [] (ZettelsView (LinkView_ShowDate) False)
-  describe "Parse zettels by ID URI" $ do
-    let zid = parseZettelID "1234567"
-    it "parses z:/" $
-      queryFromURILink (mkURILink "1234567" "z:/")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid Nothing)
-    it "parses z:/ ignoring annotation" $
-      queryFromURILink (mkURILink "1234567" "z://foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid Nothing)
-    it "parses zcf:/" $
-      queryFromURILink (mkURILink "1234567" "zcf:/")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid (Just OrdinaryConnection))
-  describe "Parse tags URI" $ do
-    it "parses zquery://tags" $
-      queryFromURILink (mkURILink "." "zquery://tags?filter=foo/**")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo/**"])
 
 shortLinks :: Spec
 shortLinks = do
@@ -77,28 +30,28 @@ shortLinks = do
     let shortLink s = mkURILink s s
     it "parses date ID" $ do
       queryFromURILink (shortLink "1234567")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "1234567") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "1234567") Folgezettel)
     it "parses custom/hash ID" $ do
       queryFromURILink (shortLink "foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Folgezettel)
     it "even with ?cf" $ do
       queryFromURILink (shortLink "foo-bar?cf")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") (Just OrdinaryConnection))
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") OrdinaryConnection)
     it "parses prefixed short link" $ do
       queryFromURILink (shortLink "z:/foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Folgezettel)
     it "resolves ambiguity using absolute URI" $ do
       queryFromURILink (shortLink "z:/tags")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "tags") Nothing)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "tags") Folgezettel)
     it "z:zettels" $ do
       queryFromURILink (shortLink "z:zettels")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] Nothing def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] Folgezettel def)
     it "z:zettels?tag=foo" $ do
       queryFromURILink (shortLink "z:zettels?tag=foo")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [mkTagPattern "foo"] Nothing def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [mkTagPattern "foo"] Folgezettel def)
     it "z:zettels?cf" $ do
       queryFromURILink (shortLink "z:zettels?cf")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] (Just OrdinaryConnection) def)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] OrdinaryConnection def)
     it "z:tags" $ do
       queryFromURILink (shortLink "z:tags")
         `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [])
@@ -107,5 +60,6 @@ shortLinks = do
         `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo"])
 
 mkURILink :: Text -> Text -> URILink
-mkURILink s l =
-  URILink s $ either (error . toText . displayException) id $ mkURI l
+mkURILink linkText s =
+  let uri = either (error . toText . displayException) id $ mkURI s
+   in URILink [Str linkText] uri True

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -10,6 +10,7 @@ where
 import Data.Default (def)
 import Data.Some
 import Data.TagTree
+import Data.Time.Calendar
 import Neuron.Zettelkasten.Connection
 import Neuron.Zettelkasten.ID
 import Neuron.Zettelkasten.Query.Parser
@@ -25,20 +26,22 @@ spec = do
   describe "short links" $ do
     let shortLink s = mkURILink s s
     it "parses date ID" $ do
-      queryFromURILink (shortLink "1234567")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "1234567") Folgezettel)
+      let day = fromGregorian 2020 3 19
+          zid = ZettelDateID day 1
+      queryFromURILink (shortLink "2011401")
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID zid Folgezettel)
     it "parses custom/hash ID" $ do
       queryFromURILink (shortLink "foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Folgezettel)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") Folgezettel)
     it "even with ?cf" $ do
       queryFromURILink (shortLink "foo-bar?cf")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") OrdinaryConnection)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
     it "parses prefixed short link" $ do
       queryFromURILink (shortLink "z:/foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") Folgezettel)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") Folgezettel)
     it "resolves ambiguity using absolute URI" $ do
       queryFromURILink (shortLink "z:/tags")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "tags") Folgezettel)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "tags") Folgezettel)
     it "z:zettels" $ do
       queryFromURILink (shortLink "z:zettels")
         `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelsByTag [] Folgezettel def)
@@ -58,7 +61,7 @@ spec = do
     let normalLink = mkURILink "some link text"
     it "Default connection type should be cf" $ do
       queryFromURILink (normalLink "foo-bar")
-        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") OrdinaryConnection)
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
 
 mkURILink :: Text -> Text -> URILink
 mkURILink linkText s =

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -22,10 +22,6 @@ import Text.URI
 
 spec :: Spec
 spec = do
-  shortLinks
-
-shortLinks :: Spec
-shortLinks = do
   describe "short links" $ do
     let shortLink s = mkURILink s s
     it "parses date ID" $ do
@@ -58,8 +54,15 @@ shortLinks = do
     it "z:tags?filter=foo" $ do
       queryFromURILink (shortLink "z:tags?filter=foo")
         `shouldBe` Right (Just $ Some $ ZettelQuery_Tags [mkTagPattern "foo"])
+  describe "flexible links (regular markdown)" $ do
+    let normalLink = mkURILink "some link text"
+    it "Default connection type should be cf" $ do
+      queryFromURILink (normalLink "foo-bar")
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (parseZettelID "foo-bar") OrdinaryConnection)
 
 mkURILink :: Text -> Text -> URILink
 mkURILink linkText s =
+  -- TODO: Do this in reflex-dom-pandoc
   let uri = either (error . toText . displayException) id $ mkURI s
-   in URILink [Str linkText] uri True
+      isAutoLink = linkText == s
+   in URILink [Str linkText] uri isAutoLink

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -62,6 +62,9 @@ spec = do
     it "Default connection type should be cf" $ do
       queryFromURILink (normalLink "foo-bar")
         `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
+    it "Supports full filename instead of zettel ID" $ do
+      queryFromURILink (normalLink "foo-bar.md")
+        `shouldBe` Right (Just $ Some $ ZettelQuery_ZettelByID (ZettelCustomID "foo-bar") OrdinaryConnection)
 
 mkURILink :: Text -> Text -> URILink
 mkURILink linkText s =

--- a/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Query/ParserSpec.hs
@@ -70,5 +70,5 @@ mkURILink :: Text -> Text -> URILink
 mkURILink linkText s =
   -- TODO: Do this in reflex-dom-pandoc
   let uri = either (error . toText . displayException) id $ mkURI s
-      isAutoLink = linkText == s
-   in URILink [Str linkText] uri isAutoLink
+      inner = if linkText == s then Nothing else Just [Str linkText]
+   in URILink inner uri


### PR DESCRIPTION
Addresses a part of #312 as well as **drops support for legacy links** <sup>(the 'zcfquery' ones)</sup>.

Example:

```markdown
This is [a regular note](foo-bar.md) link. Neuron will treat it as a `cf` link
```

Uses https://github.com/srid/reflex-dom-pandoc/pull/8

- [x] refactor
- [x] update docs