### PR TITLE
Add note about removing editUrl to avoid navbar button

### DIFF
--- a/guide/2011701.md
+++ b/guide/2011701.md
@@ -11,7 +11,7 @@ You may configure the parameters of your web interface by adding an optional con
 |**`siteBaseUrl`**|The base URL of your published Neuron site. Setting the base URL will enable [breadcrumbs](https://developers.google.com/search/docs/data-types/breadcrumb) in your site's structured data|
 |**`theme`**|Color scheme to use for your site. Value must be [one of the color names](https://semantic-ui.com/usage/theming.html#sitewide-defaults) supported by SemanticUI.|
 |**`aliases`**|Setup custom redirects in the statically generated site.|
-|**`editUrl`**|The URL (without the zettel filename) to edit zettels.|
+|**`editUrl`**|The URL (without the zettel filename) to edit zettels. To remove the edit button from the navbar, remove this entry from your configuration.|
 |**`minVersion`**|The minimum neuron version your site must be generated with.|
 |**`formats`**|Formats other than Markdown to use; eg: `["markdown", "org"]`|
 


### PR DESCRIPTION
I was interested in removing the edit navbar button since I use a local text editor for my editing.  Turns out we can just remove the editUrl entry from the configuration to do this.  This change adds a note about this to the documentation.