### PR TITLE
Allow custom HTML in `<head>`.

### DIFF
--- a/neuron/src/app/Main.hs
+++ b/neuron/src/app/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,6 +16,7 @@ import Neuron.Config.Type (Config)
 import Neuron.Version (neuronVersion)
 import Neuron.Web.Generate (generateSite)
 import Neuron.Web.Generate.Route (staticRouteConfig)
+import Neuron.Web.HeadHtml (getHeadHtml)
 import qualified Neuron.Web.Manifest as Manifest
 import Neuron.Web.Route (Route (..), runNeuronWeb)
 import Neuron.Web.View (renderRoutePage)
@@ -32,13 +34,14 @@ generateMainSite config = do
   notesDir <- ribInputDir
   buildStaticFiles ["static/**", ".nojekyll"]
   manifest <- fmap Manifest.mkManifest $ getDirectoryFiles notesDir Manifest.manifestPatterns
+  headHtml <- getHeadHtml
   let writeHtmlRoute :: Route a -> (ZettelGraph, a) -> Action ()
       writeHtmlRoute r x = do
         html <- liftIO $
           fmap snd $
             renderStatic $ do
               runNeuronWeb staticRouteConfig $
-                renderRoutePage neuronVersion config manifest r x
+                renderRoutePage neuronVersion headHtml config manifest r x
         -- FIXME: Make rib take bytestrings
         writeRoute r $ decodeUtf8 @Text html
   void $ generateSite config writeHtmlRoute

--- a/neuron/src/app/Main.hs
+++ b/neuron/src/app/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -41,7 +40,7 @@ generateMainSite config = do
           fmap snd $
             renderStatic $ do
               runNeuronWeb staticRouteConfig $
-                renderRoutePage neuronVersion headHtml config manifest r x
+                renderRoutePage neuronVersion config headHtml manifest r x
         -- FIXME: Make rib take bytestrings
         writeRoute r $ decodeUtf8 @Text html
   void $ generateSite config writeHtmlRoute

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -13,11 +13,10 @@
 
 module Neuron.Config
   ( getConfig,
-    parseConfig,
+    parsePure,
   )
 where
 
-import Data.Set ((\\), member)
 import Data.Either.Validation (validationToEither)
 import Development.Shake (Action, readFile')
 import Dhall (FromDhall)
@@ -25,9 +24,8 @@ import qualified Dhall
 import qualified Dhall.Core
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
-import qualified Dhall.Map
 import Neuron.Config.Orphans ()
-import Neuron.Config.Type (Config (..), configFile, configKeys, mergeWithDefault)
+import Neuron.Config.Type (Config, configFile, defaultConfig, mergeWithDefault)
 import Relude
 import Rib.Shake (ribInputDir)
 import System.Directory
@@ -37,43 +35,23 @@ import System.FilePath
 getConfig :: Action Config
 getConfig = do
   configPath <- ribInputDir <&> (</> configFile)
-  configVal :: Maybe Text <-
+  configVal :: Text <-
     liftIO (doesFileExist configPath) >>= \case
-      True ->
-        Just . toText <$> readFile' configPath
+      True -> do
+        mergeWithDefault . toText <$> readFile' configPath
       False ->
-        pure Nothing
-  either fail pure $ parseConfig configFile $ mergeWithDefault configVal
+        pure defaultConfig
+  either fail pure $ parsePure configFile $ mergeWithDefault configVal
 
--- | Pure version of @'Dhall.input' 'Dhall.auto'@ that also returns the type.
+-- | Pure version of `Dhall.input Dhall.auto`
 --
--- The parsed file cannot have imports, as that requires IO.
-parsePure :: FromDhall a => FilePath -> Text -> Either String (a, Dhall.Core.Expr Dhall.Parser.Src Void)
+-- The config file cannot have imports, as that requires IO.
+parsePure :: forall a. FromDhall a => FilePath -> Text -> Either String a
 parsePure fn s = do
   expr0 <- first show $ Dhall.Parser.exprFromText fn s
   expr <- maybeToRight "Cannot have imports" $ traverse (const Nothing) expr0
-  typ <- first show $ Dhall.TypeCheck.typeOf expr
-  val <- first show $ validationToEither $ Dhall.extract Dhall.auto $ Dhall.Core.normalize expr
-  pure (val, typ)
-
--- | Parse a Neuron Dhall config file.
---
--- The config file cannot have imports, as that requires IO.
--- The config file also cannot have spurious fields outside of those defined in 'Config'.
--- (Exception: for backwards compatibility, silently ignore a spurious @mathJaxSupport@ field
--- if it is the only spurious field.)
-parseConfig :: FilePath -> Text -> Either String Config
-parseConfig fn s = do
-  (config, Dhall.Core.Record (Dhall.Map.keysSet -> fields)) <- parsePure fn s
-  let spuriousFields = fields \\ configKeys
-  if null $ spuriousFields \\ one "mathJaxSupport"
-    then pure config
-    else do
-      let spuriousMessage =
-            "Configuration in neuron.dhall includes spurious fields: " <>
-            intercalate ", " (("`" <>) . (<> "`") . toString <$> toList spuriousFields) <> "."
-          mathJaxMessage =
-            if "mathJaxSupport" `member` spuriousFields
-              then " To disable MathJax support, include a (possibly blank) `./head.html` file."
-              else ""
-      fail $ spuriousMessage <> mathJaxMessage
+  void $ first show $ Dhall.TypeCheck.typeOf expr
+  first show $
+    validationToEither $
+      Dhall.extract @a Dhall.auto $
+        Dhall.Core.normalize expr

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -13,7 +13,7 @@
 
 module Neuron.Config
   ( getConfig,
-    parsePure,
+    parseConfig,
   )
 where
 
@@ -27,7 +27,7 @@ import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
 import qualified Dhall.Map
 import Neuron.Config.Orphans ()
-import Neuron.Config.Type (Config (..), configFile, configKeys, emptyConfig, mergeWithDefault)
+import Neuron.Config.Type (Config (..), configFile, configKeys, mergeWithDefault)
 import Relude
 import Rib.Shake (ribInputDir)
 import System.Directory
@@ -37,37 +37,43 @@ import System.FilePath
 getConfig :: Action Config
 getConfig = do
   configPath <- ribInputDir <&> (</> configFile)
-  configVal :: Text <-
+  configVal :: Maybe Text <-
     liftIO (doesFileExist configPath) >>= \case
       True ->
-        toText <$> readFile' configPath
+        Just . toText <$> readFile' configPath
       False ->
-        pure emptyConfig
-  either fail pure $ parsePure configFile $ mergeWithDefault configVal
+        pure Nothing
+  either fail pure $ parseConfig configFile $ mergeWithDefault configVal
 
--- | Pure version of `Dhall.input Dhall.auto`
+-- | Pure version of @'Dhall.input' 'Dhall.auto'@ that also returns the type.
 --
--- The config file cannot have imports, as that requires IO.
-parsePure :: forall a. FromDhall a => FilePath -> Text -> Either String a
+-- The parsed file cannot have imports, as that requires IO.
+parsePure :: FromDhall a => FilePath -> Text -> Either String (a, Dhall.Core.Expr Dhall.Parser.Src Void)
 parsePure fn s = do
   expr0 <- first show $ Dhall.Parser.exprFromText fn s
   expr <- maybeToRight "Cannot have imports" $ traverse (const Nothing) expr0
-  Dhall.Core.Record (Dhall.Map.keysSet -> fields) <- first show $ Dhall.TypeCheck.typeOf expr
+  typ <- first show $ Dhall.TypeCheck.typeOf expr
+  val <- first show $ validationToEither $ Dhall.extract Dhall.auto $ Dhall.Core.normalize expr
+  pure (val, typ)
+
+-- | Parse a Neuron Dhall config file.
+--
+-- The config file cannot have imports, as that requires IO.
+-- The config file also cannot have spurious fields outside of those defined in 'Config'.
+-- (Exception: for backwards compatibility, silently ignore a spurious @mathJaxSupport@ field
+-- if it is the only spurious field.)
+parseConfig :: FilePath -> Text -> Either String Config
+parseConfig fn s = do
+  (config, Dhall.Core.Record (Dhall.Map.keysSet -> fields)) <- parsePure fn s
   let spuriousFields = fields \\ configKeys
-  case null spuriousFields of
-    True ->
-      first show $
-        validationToEither $
-          Dhall.extract @a Dhall.auto $
-            Dhall.Core.normalize expr
-    False -> do
+  if null $ spuriousFields \\ one "mathJaxSupport"
+    then pure config
+    else do
       let spuriousMessage =
             "Configuration in neuron.dhall includes spurious fields: " <>
-            intercalate ", " (("`" <>) . (<> "`") . toString <$> toList spuriousFields) <>
-            "."
-          -- TODO: remove once
+            intercalate ", " (("`" <>) . (<> "`") . toString <$> toList spuriousFields) <> "."
           mathJaxMessage =
             if "mathJaxSupport" `member` spuriousFields
               then " To disable MathJax support, include a (possibly blank) `./head.html` file."
               else ""
-      Left $ spuriousMessage <> mathJaxMessage
+      fail $ spuriousMessage <> mathJaxMessage

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -17,6 +17,7 @@ module Neuron.Config
   )
 where
 
+import Data.Set ((\\), member)
 import Data.Either.Validation (validationToEither)
 import Development.Shake (Action, readFile')
 import Dhall (FromDhall)
@@ -24,8 +25,9 @@ import qualified Dhall
 import qualified Dhall.Core
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
+import qualified Dhall.Map
 import Neuron.Config.Orphans ()
-import Neuron.Config.Type (Config (..), configFile, emptyConfig, mergeWithDefault)
+import Neuron.Config.Type (Config (..), configFile, configKeys, emptyConfig, mergeWithDefault)
 import Relude
 import Rib.Shake (ribInputDir)
 import System.Directory
@@ -50,8 +52,22 @@ parsePure :: forall a. FromDhall a => FilePath -> Text -> Either String a
 parsePure fn s = do
   expr0 <- first show $ Dhall.Parser.exprFromText fn s
   expr <- maybeToRight "Cannot have imports" $ traverse (const Nothing) expr0
-  void $ first show $ Dhall.TypeCheck.typeOf expr
-  first show $
-    validationToEither $
-      Dhall.extract @a Dhall.auto $
-        Dhall.Core.normalize expr
+  Dhall.Core.Record (Dhall.Map.keysSet -> fields) <- first show $ Dhall.TypeCheck.typeOf expr
+  let spuriousFields = fields \\ configKeys
+  case null spuriousFields of
+    True ->
+      first show $
+        validationToEither $
+          Dhall.extract @a Dhall.auto $
+            Dhall.Core.normalize expr
+    False -> do
+      let spuriousMessage =
+            "Configuration in neuron.dhall includes spurious fields: " <>
+            intercalate ", " (("`" <>) . (<> "`") . toString <$> toList spuriousFields) <>
+            "."
+          -- TODO: remove once
+          mathJaxMessage =
+            if "mathJaxSupport" `member` spuriousFields
+              then " To disable MathJax support, include a (possibly blank) `./head.html` file."
+              else ""
+      Left $ spuriousMessage <> mathJaxMessage

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -25,7 +25,7 @@ import qualified Dhall.Core
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
 import Neuron.Config.Orphans ()
-import Neuron.Config.Type (Config (..), configFile, headHtmlFile, emptyConfig, mergeWithDefault)
+import Neuron.Config.Type (Config (..), configFile, emptyConfig, mergeWithDefault)
 import Relude
 import Rib.Shake (ribInputDir)
 import System.Directory
@@ -41,21 +41,7 @@ getConfig = do
         toText <$> readFile' configPath
       False ->
         pure emptyConfig
-  headHtmlPath <- ribInputDir <&> (</> headHtmlFile)
-  headHtmlVal <-
-    liftIO (doesFileExist headHtmlPath) >>= \case
-      True ->
-        Just . toText <$> readFile' headHtmlPath
-      False ->
-        pure Nothing
-  config <- either fail pure $ parsePure configFile $ mergeWithDefault configVal
-  case (headHtml config, headHtmlVal) of
-    (Just _, Just _) ->
-      fail "Can either include `head.html` file, or set `headHtml` to a `Some` value in `neuron.dhall`, but not both."
-    (Nothing, Just _) ->
-      pure config{headHtml = headHtmlVal}
-    _ ->
-      pure config
+  either fail pure $ parsePure configFile $ mergeWithDefault configVal
 
 -- | Pure version of `Dhall.input Dhall.auto`
 --

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -28,7 +28,7 @@ import Data.Some
 import Data.TagTree (Tag (..))
 import Neuron.Config.Type (Config (..))
 import Neuron.Web.Common (neuronCommonStyle, neuronFonts)
-import Neuron.Web.HeadHtml (HeadHtml, renderHeadHtmlOr)
+import Neuron.Web.HeadHtml (HeadHtml, renderHeadHtml)
 import Neuron.Web.Manifest (Manifest, renderManifest)
 import qualified Neuron.Web.Query.View as QueryView
 import Neuron.Web.Route
@@ -50,17 +50,17 @@ import qualified Skylighting.Format.HTML as Skylighting
 import qualified Skylighting.Styles as Skylighting
 
 -- | Render the given route
-renderRoutePage :: PandocBuilder t m => Text -> HeadHtml -> Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
-renderRoutePage neuronVersion headHtml config manifest r val = do
+renderRoutePage :: PandocBuilder t m => Text -> Config -> HeadHtml -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
+renderRoutePage neuronVersion config headHtml manifest r val = do
   el "!DOCTYPE html" $ pure ()
   elAttr "html" ("lang" =: "en") $ do
     el "head" $ do
-      renderRouteHead headHtml config manifest r val
+      renderRouteHead config headHtml manifest r val
     el "body" $ do
       renderRouteBody neuronVersion config r val
 
-renderRouteHead :: PandocBuilder t m => HeadHtml -> Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
-renderRouteHead headHtml config manifest route val = do
+renderRouteHead :: PandocBuilder t m => Config -> HeadHtml -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
+renderRouteHead config headHtml manifest route val = do
   elAttr "meta" ("http-equiv" =: "Content-Type" <> "content" =: "text/html; charset=utf-8") blank
   elAttr "meta" ("name" =: "viewport" <> "content" =: "width=device-width, initial-scale=1") blank
   el "title" $ text $ routeTitle config (snd val) route
@@ -87,9 +87,7 @@ renderRouteHead headHtml config manifest route val = do
       elAttr "link" ("rel" =: "stylesheet" <> "href" =: "https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.5/dist/semantic.min.css") blank
       elAttr "style" ("type" =: "text/css") $ text neuronCss
       elLinkGoogleFonts neuronFonts
-      -- Include the MathJax script unless a custom head.html is provided.
-      renderHeadHtmlOr headHtml $
-        elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
+      renderHeadHtml headHtml
     routeTitle :: Config -> a -> Route a -> Text
     routeTitle Config {..} v =
       withSuffix siteTitle . routeTitle' v

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -52,7 +52,8 @@ import qualified Skylighting.Styles as Skylighting
 -- | Render the given route
 renderRoutePage :: PandocBuilder t m => Text -> Config -> HeadHtml -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
 renderRoutePage neuronVersion config headHtml manifest r val = do
-  el "!DOCTYPE html" $ pure ()
+  -- DOCTYPE declaration is helpful for code that might appear in the user's `head.html` file (e.g. KaTeX).
+  el "!DOCTYPE html" $ blank
   elAttr "html" ("lang" =: "en") $ do
     el "head" $ do
       renderRouteHead config headHtml manifest r val

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -87,7 +87,8 @@ renderRouteHead headHtml config manifest route val = do
       elAttr "link" ("rel" =: "stylesheet" <> "href" =: "https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.5/dist/semantic.min.css") blank
       elAttr "style" ("type" =: "text/css") $ text neuronCss
       elLinkGoogleFonts neuronFonts
-      renderHeadHtmlOr headHtml . when (mathJaxSupport config) $
+      -- Include the MathJax script unless a custom head.html is provided.
+      renderHeadHtmlOr headHtml $
         elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
     routeTitle :: Config -> a -> Route a -> Text
     routeTitle Config {..} v =

--- a/neuron/src/app/Neuron/Web/View.hs
+++ b/neuron/src/app/Neuron/Web/View.hs
@@ -28,6 +28,7 @@ import Data.Some
 import Data.TagTree (Tag (..))
 import Neuron.Config.Type (Config (..))
 import Neuron.Web.Common (neuronCommonStyle, neuronFonts)
+import Neuron.Web.HeadHtml (HeadHtml, renderHeadHtmlOr)
 import Neuron.Web.Manifest (Manifest, renderManifest)
 import qualified Neuron.Web.Query.View as QueryView
 import Neuron.Web.Route
@@ -44,24 +45,22 @@ import Neuron.Zettelkasten.ID (ZettelID (..))
 import Neuron.Zettelkasten.Zettel
 import Reflex.Dom.Core hiding ((&))
 import Reflex.Dom.Pandoc (PandocBuilder)
-import Reflex.Dom.Pandoc.PandocRaw (PandocRaw (..))
 import Relude hiding ((&))
 import qualified Skylighting.Format.HTML as Skylighting
 import qualified Skylighting.Styles as Skylighting
-import Text.Pandoc.Definition (Format (..))
 
 -- | Render the given route
-renderRoutePage :: PandocBuilder t m => Text -> Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
-renderRoutePage neuronVersion config manifest r val = do
+renderRoutePage :: PandocBuilder t m => Text -> HeadHtml -> Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
+renderRoutePage neuronVersion headHtml config manifest r val = do
   el "!DOCTYPE html" $ pure ()
   elAttr "html" ("lang" =: "en") $ do
     el "head" $ do
-      renderRouteHead config manifest r val
+      renderRouteHead headHtml config manifest r val
     el "body" $ do
       renderRouteBody neuronVersion config r val
 
-renderRouteHead :: PandocBuilder t m => Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
-renderRouteHead config manifest route val = do
+renderRouteHead :: PandocBuilder t m => HeadHtml -> Config -> Manifest -> Route a -> (ZettelGraph, a) -> NeuronWebT t m ()
+renderRouteHead headHtml config manifest route val = do
   elAttr "meta" ("http-equiv" =: "Content-Type" <> "content" =: "text/html; charset=utf-8") blank
   elAttr "meta" ("name" =: "viewport" <> "content" =: "width=device-width, initial-scale=1") blank
   el "title" $ text $ routeTitle config (snd val) route
@@ -69,7 +68,8 @@ renderRouteHead config manifest route val = do
   case route of
     Route_Redirect _ ->
       blank
-    Route_Search {} -> renderCommon $ do
+    Route_Search {} -> do
+      renderCommon
       forM_
         [ "https://cdn.jsdelivr.net/npm/jquery@3.5.0/dist/jquery.min.js",
           "https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js",
@@ -77,22 +77,18 @@ renderRouteHead config manifest route val = do
         ]
         $ \scrpt -> do
           elAttr "script" ("src" =: scrpt) blank
-    _ -> renderCommon $ do
+    _ -> do
+      renderCommon
       renderStructuredData config route val
       elAttr "style" ("type" =: "text/css") $ text $ toText $ Skylighting.styleToCss Skylighting.tango
   where
-    renderCommon renderMiddle = do
-      -- Common prologue
+    renderCommon = do
       let neuronCss = toText $ C.renderWith C.compact [] style
       elAttr "link" ("rel" =: "stylesheet" <> "href" =: "https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.5/dist/semantic.min.css") blank
       elAttr "style" ("type" =: "text/css") $ text neuronCss
       elLinkGoogleFonts neuronFonts
-      when (mathJaxSupport config) $
+      renderHeadHtmlOr headHtml . when (mathJaxSupport config) $
         elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
-      -- Head content
-      renderMiddle
-      -- Common epilogue
-      forM_ (headHtml config) $ elPandocRaw (Format "html")
     routeTitle :: Config -> a -> Route a -> Text
     routeTitle Config {..} v =
       withSuffix siteTitle . routeTitle' v

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -33,7 +33,6 @@ data Config = Config
   { aliases :: [Text],
     author :: Maybe Text,
     editUrl :: Maybe Text,
-    mathJaxSupport :: Bool,
     -- TODO: This should use `NonEmpty`.
     formats :: [Text],
     minVersion :: Text,
@@ -67,8 +66,6 @@ defaultConfig =
   \   [] : List Text\
   \, formats =\
   \   [ \"markdown\" ]\
-  \, mathJaxSupport =\
-  \   True\
   \, minVersion =\
   \   \"0.5\" \
   \}"

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -10,6 +10,7 @@
 module Neuron.Config.Type
   ( Config (..),
     configFile,
+    configKeys,
     emptyConfig,
     mergeWithDefault,
     getZettelFormats,
@@ -49,6 +50,18 @@ getZettelFormats Config {..} = do
 
 emptyConfig :: Text
 emptyConfig = "{}"
+
+configKeys :: Set Text
+configKeys = fromList
+  [ "aliases",
+    "author",
+    "editUrl",
+    "formats",
+    "minVersion",
+    "siteBaseUrl",
+    "siteTitle",
+    "theme"
+  ]
 
 defaultConfig :: Text
 defaultConfig =

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -10,7 +10,8 @@
 module Neuron.Config.Type
   ( Config (..),
     configFile,
-    defaultConfig,
+    headHtmlFile,
+    emptyConfig,
     mergeWithDefault,
     getZettelFormats,
   )
@@ -23,6 +24,9 @@ import Text.Read (readEither)
 
 configFile :: FilePath
 configFile = "neuron.dhall"
+
+headHtmlFile :: FilePath
+headHtmlFile = "head.html"
 
 -- | Config type for @neuron.dhall@
 --
@@ -39,7 +43,8 @@ data Config = Config
     minVersion :: Text,
     siteBaseUrl :: Maybe Text,
     siteTitle :: Text,
-    theme :: Text
+    theme :: Text,
+    headHtml :: Maybe Text
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
@@ -47,6 +52,9 @@ getZettelFormats :: MonadFail m => Config -> m (NonEmpty ZettelFormat)
 getZettelFormats Config {..} = do
   formats' <- maybe (fail "Empty formats") pure $ nonEmpty formats
   traverse (either (fail . toString) pure . readEither . toString) formats'
+
+emptyConfig :: Text
+emptyConfig = "{}"
 
 defaultConfig :: Text
 defaultConfig =
@@ -68,6 +76,8 @@ defaultConfig =
   \   True\
   \, minVersion =\
   \   \"0.5\" \
+  \, headHtml =\
+  \   None Text\
   \}"
 
 -- Dhall's combine operator (`//`) allows us to merge two records,

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -11,7 +11,6 @@ module Neuron.Config.Type
   ( Config (..),
     configFile,
     configKeys,
-    emptyConfig,
     mergeWithDefault,
     getZettelFormats,
   )
@@ -48,9 +47,6 @@ getZettelFormats Config {..} = do
   formats' <- maybe (fail "Empty formats") pure $ nonEmpty formats
   traverse (either (fail . toString) pure . readEither . toString) formats'
 
-emptyConfig :: Text
-emptyConfig = "{}"
-
 configKeys :: Set Text
 configKeys = fromList
   [ "aliases",
@@ -85,6 +81,7 @@ defaultConfig =
 
 -- Dhall's combine operator (`//`) allows us to merge two records,
 -- effectively merging the record with defaults with the user record.
-mergeWithDefault :: Text -> Text
-mergeWithDefault userConfig =
-  defaultConfig <> " // " <> userConfig
+mergeWithDefault :: Maybe Text -> Text
+mergeWithDefault = \case
+  Nothing -> defaultConfig
+  Just userConfig -> defaultConfig <> " // " <> userConfig

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -10,7 +10,6 @@
 module Neuron.Config.Type
   ( Config (..),
     configFile,
-    headHtmlFile,
     emptyConfig,
     mergeWithDefault,
     getZettelFormats,
@@ -24,9 +23,6 @@ import Text.Read (readEither)
 
 configFile :: FilePath
 configFile = "neuron.dhall"
-
-headHtmlFile :: FilePath
-headHtmlFile = "head.html"
 
 -- | Config type for @neuron.dhall@
 --
@@ -43,8 +39,7 @@ data Config = Config
     minVersion :: Text,
     siteBaseUrl :: Maybe Text,
     siteTitle :: Text,
-    theme :: Text,
-    headHtml :: Maybe Text
+    theme :: Text
   }
   deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
@@ -76,8 +71,6 @@ defaultConfig =
   \   True\
   \, minVersion =\
   \   \"0.5\" \
-  \, headHtml =\
-  \   None Text\
   \}"
 
 -- Dhall's combine operator (`//`) allows us to merge two records,

--- a/neuron/src/lib/Neuron/Config/Type.hs
+++ b/neuron/src/lib/Neuron/Config/Type.hs
@@ -10,7 +10,7 @@
 module Neuron.Config.Type
   ( Config (..),
     configFile,
-    configKeys,
+    defaultConfig,
     mergeWithDefault,
     getZettelFormats,
   )
@@ -47,18 +47,6 @@ getZettelFormats Config {..} = do
   formats' <- maybe (fail "Empty formats") pure $ nonEmpty formats
   traverse (either (fail . toString) pure . readEither . toString) formats'
 
-configKeys :: Set Text
-configKeys = fromList
-  [ "aliases",
-    "author",
-    "editUrl",
-    "formats",
-    "minVersion",
-    "siteBaseUrl",
-    "siteTitle",
-    "theme"
-  ]
-
 defaultConfig :: Text
 defaultConfig =
   "{ siteTitle =\
@@ -81,7 +69,6 @@ defaultConfig =
 
 -- Dhall's combine operator (`//`) allows us to merge two records,
 -- effectively merging the record with defaults with the user record.
-mergeWithDefault :: Maybe Text -> Text
-mergeWithDefault = \case
-  Nothing -> defaultConfig
-  Just userConfig -> defaultConfig <> " // " <> userConfig
+mergeWithDefault :: Text -> Text
+mergeWithDefault userConfig =
+  defaultConfig <> " // " <> userConfig

--- a/neuron/src/lib/Neuron/Web/HeadHtml.hs
+++ b/neuron/src/lib/Neuron/Web/HeadHtml.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Neuron.Web.HeadHtml
+  ( HeadHtml,
+    getHeadHtml,
+    renderHeadHtmlOr,
+  )
+where
+
+import Development.Shake
+import Relude
+import Reflex.Dom.Pandoc (PandocBuilder)
+import Reflex.Dom.Pandoc.PandocRaw (PandocRaw (..))
+import Rib.Shake (ribInputDir)
+import System.FilePath ((</>))
+import Text.Pandoc.Definition (Format (..))
+
+newtype HeadHtml = HeadHtml (Maybe Text)
+
+getHeadHtml :: Action HeadHtml
+getHeadHtml = do
+  headHtmlPath <- ribInputDir <&> (</> "head.html")
+  doesFileExist headHtmlPath >>= \case
+    True ->
+      HeadHtml . Just . toText <$> readFile' headHtmlPath
+    False ->
+      pure $ HeadHtml Nothing
+
+renderHeadHtmlOr :: PandocBuilder t m => HeadHtml -> m () -> m ()
+renderHeadHtmlOr (HeadHtml headHtml) other = case headHtml of
+  Nothing -> other
+  Just html -> elPandocRaw (Format "html") html

--- a/neuron/src/lib/Neuron/Web/HeadHtml.hs
+++ b/neuron/src/lib/Neuron/Web/HeadHtml.hs
@@ -5,12 +5,13 @@
 module Neuron.Web.HeadHtml
   ( HeadHtml,
     getHeadHtml,
-    renderHeadHtmlOr,
+    renderHeadHtml,
   )
 where
 
 import Development.Shake
 import Relude
+import Reflex.Dom.Core
 import Reflex.Dom.Pandoc (PandocBuilder)
 import Reflex.Dom.Pandoc.PandocRaw (PandocRaw (..))
 import Rib.Shake (ribInputDir)
@@ -28,7 +29,10 @@ getHeadHtml = do
     False ->
       pure $ HeadHtml Nothing
 
-renderHeadHtmlOr :: PandocBuilder t m => HeadHtml -> m () -> m ()
-renderHeadHtmlOr (HeadHtml headHtml) other = case headHtml of
-  Nothing -> other
-  Just html -> elPandocRaw (Format "html") html
+renderHeadHtml :: PandocBuilder t m => HeadHtml -> m ()
+renderHeadHtml (HeadHtml headHtml) = case headHtml of
+  Nothing ->
+    -- Include the MathJax script if no custom head.html is provided.
+    elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
+  Just html ->
+    elPandocRaw (Format "html") html


### PR DESCRIPTION
Adds `headHtml : Optional Text` option to the configuration. It can be set in one of two ways, but not both simultaneously.

- The option can be set as usual in `./neuron.dhall`.
- If the file `./head.html` exists, then `headHtml` is set to `Some [head.html's contents]`.

Addresses #362 directly. Also solves or enables workarounds for several other issues (e.g. #212, #361, #383).