### PR TITLE
Add lower bound dependent-sum-aeson-orphans >= 0.2.1.0

### DIFF
--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -57,7 +57,7 @@ common library-common
     aeson-gadt-th,
     dependent-sum,
     dependent-sum-template,
-    dependent-sum-aeson-orphans,
+    dependent-sum-aeson-orphans >= 0.2.1.0,
     data-default,
     reflex,
     reflex-dom-core,


### PR DESCRIPTION
This is the version that introduces an orphan instance for Some,
needed to derive ToJSON/FromJSON instances for `Zettel` in
`lib/Neuron/Zettelkasten/Zettel.hs`.