### PR TITLE
Bracketed spans in Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     - Fix hard line breaks to actually work (#354)
   - Allow dot in Zettel ID (#369)
   - Drop support for legacy date IDs (#368)
+  - Add [`bracked_spans`](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/bracketed_spans.md) extension
 - CLI
   - Faster querying: add `--cached` option to `neuron query`, to run faster using the cache. To keep the cache up to date, make sure that `neuron rib` is running.
   - Add `--id` and `--search` options to `open` command to open given zettel ID or search page respectively  (#317)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
     - Fix hard line breaks to actually work (#354)
   - Allow dot in Zettel ID (#369)
   - Drop support for legacy date IDs (#368)
-  - Add [`bracked_spans`](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/bracketed_spans.md) extension
+  - Add [`bracked_spans`](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/bracketed_spans.md) extension (#406)
 - CLI
   - Faster querying: add `--cached` option to `neuron query`, to run faster using the cache. To keep the cache up to date, make sure that `neuron rib` is running.
   - Add `--id` and `--search` options to `open` command to open given zettel ID or search page respectively  (#317)

--- a/guide/index.md
+++ b/guide/index.md
@@ -1,6 +1,6 @@
 # Neuron Zettelkasten
 
-[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your [plain-text notes]{.ui .red .text} in [[[zettelkasten]]] style, as well as for publishing them on the web. Read its [[[6f0f0bcc]]].
+[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your plain-text notes in [[[zettelkasten]]] style, as well as for publishing them on the web. Read its [[[6f0f0bcc]]].
 
 ![Neuron logo](https://raw.githubusercontent.com/srid/neuron/master/assets/neuron.svg){.ui .small .centered .image}
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -1,6 +1,6 @@
 # Neuron Zettelkasten
 
-[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your plain-text notes in [[[zettelkasten]]] style, as well as for publishing them on the web. Read its [[[6f0f0bcc]]].
+[Neuron](https://github.com/srid/neuron) is a future-proof open-source app[^web] for managing your [plain-text notes]{.ui .red .text} in [[[zettelkasten]]] style, as well as for publishing them on the web. Read its [[[6f0f0bcc]]].
 
 ![Neuron logo](https://raw.githubusercontent.com/srid/neuron/master/assets/neuron.svg){.ui .small .centered .image}
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 0.6.12.2
+version: 0.6.12.3
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src/lib/Neuron/Reader/Markdown.hs
+++ b/neuron/src/lib/Neuron/Reader/Markdown.hs
@@ -105,7 +105,8 @@ neuronSpec ::
     CE.HasMath il,
     CE.HasDefinitionList il bl,
     CE.HasDiv bl,
-    CE.HasQuoted il
+    CE.HasQuoted il,
+    CE.HasSpan il
   ) =>
   CM.SyntaxSpec m il bl
 neuronSpec =
@@ -122,6 +123,7 @@ neuronSpec =
       CE.attributesSpec,
       CE.rawAttributeSpec,
       CE.fencedDivSpec,
+      CE.bracketedSpanSpec,
       CM.defaultSyntaxSpec {CM.syntaxBlockSpecs = defaultBlockSpecsSansRawHtml}
     ]
   where


### PR DESCRIPTION
Add [bracked_spans](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/bracketed_spans.md) extension to Markdown parser.

This extension allows setting custom html attributes (such as the Semantic UI classes from #176) on any inline text. For example:

```markdown
This is a paragraph [with this text]{.ui .red .text} in red.
```

which renders as:

![image](https://user-images.githubusercontent.com/3998/93627978-c8b52b80-f9b3-11ea-8307-700bc5f422a7.png)

