### PR TITLE
Make sure we don't use the pinned nixpkgs if another one is provided

### DIFF
--- a/project.nix
+++ b/project.nix
@@ -7,6 +7,7 @@ let
   nixpkgs = import sources.nixpkgs {};
 in {
   pkgs ? nixpkgs,
+  pkgsForBins ? nixpkgs,
   neuronFlags ? [],
   disableHsLuaTests ? false,
   withHoogle ? false,
@@ -35,7 +36,7 @@ let
     cp $src/src-bash/neuron-search $out/bin/neuron-search
     chmod +x $out/bin/neuron-search
     wrapProgram $out/bin/neuron-search --prefix 'PATH' ':' ${
-      with pkgs;
+      with pkgsForBins;
       lib.makeBinPath [ fzf ripgrep gawk bat findutils envsubst ]
     }
     PATH=$PATH:$out/bin

--- a/project.nix
+++ b/project.nix
@@ -7,7 +7,7 @@ let
   nixpkgs = import sources.nixpkgs {};
 in {
   pkgs ? nixpkgs,
-  pkgsForBins ? nixpkgs,
+  pkgsForBins ? null,
   neuronFlags ? [],
   disableHsLuaTests ? false,
   withHoogle ? false,
@@ -36,7 +36,7 @@ let
     cp $src/src-bash/neuron-search $out/bin/neuron-search
     chmod +x $out/bin/neuron-search
     wrapProgram $out/bin/neuron-search --prefix 'PATH' ':' ${
-      with pkgsForBins;
+      with (if pkgsForBins != null then pkgsForBins else pkgs);
       lib.makeBinPath [ fzf ripgrep gawk bat findutils envsubst ]
     }
     PATH=$PATH:$out/bin

--- a/project.nix
+++ b/project.nix
@@ -35,7 +35,7 @@ let
     cp $src/src-bash/neuron-search $out/bin/neuron-search
     chmod +x $out/bin/neuron-search
     wrapProgram $out/bin/neuron-search --prefix 'PATH' ':' ${
-      with nixpkgs;
+      with pkgs;
       lib.makeBinPath [ fzf ripgrep gawk bat findutils envsubst ]
     }
     PATH=$PATH:$out/bin

--- a/static.nix
+++ b/static.nix
@@ -6,6 +6,9 @@ let
 in 
   (import ./project.nix { 
     inherit pkgs;
+    # We have to use original nixpkgs for fzf, etc. otherwise this will give
+    #   error: missing bootstrap url for platform x86_64-unknown-linux-musl
+    pkgsForBins = import sources.nixpkgs {};
     disableHsLuaTests = true; 
     neuronFlags = [
       "--ghc-option=-optl=-static"


### PR DESCRIPTION
This allows passing a `pkgs` argument to `project.nix` to prevent the pinned nixpkgs from being evaluated.

I use that in my flaked home-manager setup (where evaluating nixpkgs is not possible if a system is not explicitly passed).