### PR TITLE
Documentation for using raw HTML in notes

### DIFF
--- a/guide/markdown.md
+++ b/guide/markdown.md
@@ -2,7 +2,6 @@
 
 Zettel files are written in Markdown[^other], per the [CommonMark](https://commonmark.org/) specification. Neuron uses [commonmark-hs](https://github.com/jgm/commonmark-hs) to parse them into the [Pandoc AST](https://pandoc.org/using-the-pandoc-api.html), as well as provides an extention on top to handle zettel links.
 
-* [[[using-html-in-markdown]]]
 * [[[linking]]]
 * [[[tags]]]
 * [[[metadata]]]
@@ -10,5 +9,6 @@ Zettel files are written in Markdown[^other], per the [CommonMark](https://commo
 * [[[math]]]
 * [[[2016401]]]
 * Styling elements using Semantic UI ([\#176](https://github.com/srid/neuron/issues/176))
+* [[[raw-html]]]
 
 [^other]: Neuron is designed to be extended with other markup formats as well. Org-mode is currently supported (see the `formats` setting in [[configuration]]) but not all features work with it. Neuron recommends Markdown, which is supported everywhere including [[cerveau]].  

--- a/guide/markdown.md
+++ b/guide/markdown.md
@@ -2,6 +2,7 @@
 
 Zettel files are written in Markdown[^other], per the [CommonMark](https://commonmark.org/) specification. Neuron uses [commonmark-hs](https://github.com/jgm/commonmark-hs) to parse them into the [Pandoc AST](https://pandoc.org/using-the-pandoc-api.html), as well as provides an extention on top to handle zettel links.
 
+* [[[using-html-in-markdown]]]
 * [[[linking]]]
 * [[[tags]]]
 * [[[metadata]]]

--- a/guide/raw-html.md
+++ b/guide/raw-html.md
@@ -47,7 +47,7 @@ results in the following generated HTML:
 If the top-level HTML element has one or more attributes, neuron will never
 parse it as a link.
 
-This will likely happen without notice for elements like `iframe` (say, a Youtube embed), since they depend heavily attribute values. For simpler elements, something as small as adding an id works:
+This will likely happen without notice for elements like `iframe` (say, a Youtube embed), since they depend heavily attribute values. For simpler elements, something as small as adding an `id` works:
 
 
 ```````````````````````````````` example

--- a/guide/raw-html.md
+++ b/guide/raw-html.md
@@ -1,6 +1,6 @@
-# Using HTML in Markdown, in Neuron
+# Using raw HTML in Markdown
 
-Usually, Markdown supports raw HTML inline as valid Markdown syntax.
+Usually, Markdown supports [raw HTML inline as valid Markdown syntax](https://spec.commonmark.org/0.28/#raw-html).
 
 Because Neuron previously used an angle-bracket syntax for linking (`<note>` would generate a link to `note.md`), when Neuron encounters a simple HTML tag in a note, it is parsed as if it were a link. This link format is now deprecated, but is still supported (see footnote on [[linking]]).
 This may be changed in the future if a reliable migration path is identified (i.e. a script that would automatically convert angle-bracket links to wiki-links).
@@ -10,17 +10,17 @@ This may be changed in the future if a reliable migration path is identified (i.
 In order to get raw HTML to work in a note, for example to embed a `<video />` element, there are two options:
 
 1. Wrap the HTML in a code-block with a 'raw-attribute', which causes the code block to be interpreted as raw inline content
-2. Add an HTML attribute to your element, like `class` or `name`, which causes Neuron to recognize that element is not a note link
+2. Add an HTML attribute to your element, like `id`, `class` or `name`, which causes Neuron to recognize that element is not a note link
 
-### Using raw-attributes to insert HTML
+### Using fenced code blocks
 
-The Haskell Commonmark interpreter supports ['raw-attributes' to cause the code in the block to be interpreted as inline](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/raw_attribute.md).
+The Haskell CommonMark interpreter supports ['raw-attributes' to cause the code in the block to be interpreted as inline](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/raw_attribute.md).
 
 From the docs:
 
 > If attached to a fenced code block, it causes the block to be interpreted as raw block content with the specified format.
 
-For HTML, this just requires adding `{=html}` after the opening ` ``` ` codeblock fence.
+For HTML, this just requires adding `{=html}` after the opening ` ``` ` code block fence.
 
 So, the following markdown content:
 
@@ -30,7 +30,7 @@ So, the following markdown content:
 Here is a video:
 
 ``` {=html}
-<video><source src='static/video.mp4 /></video>
+<video><source src='static/video.mp4' /></video>
 ```
 ````````````````````````````````
 
@@ -39,14 +39,15 @@ results in the following generated HTML:
 ```````````````````````````````` example
 <h2>Some markdown interspersed with HTML</h3>
 <p>Here is a video:</p>
-<video><source src='static/video.mp4 /></video>
+<video><source src='static/video.mp4' /></video>
 ````````````````````````````````
 
-### Using HTML attributes to cause Neuron to recognize HTML elements
+### Using HTML attributes
 
-If an HTML attribute is added to an element, Neuron ignores it while generating the link heterarchy and passes it unchanged to the Markdown parser.
+If the top-level HTML element has one or more attributes, neuron will never
+parse it as a link.
 
-This will likely happen without notice for elements like `iframe` (say, a Youtube embed), since they depend heavily attribute values. For simpler elements, something as small as adding an innocuous and arbitrary class works:
+This will likely happen without notice for elements like `iframe` (say, a Youtube embed), since they depend heavily attribute values. For simpler elements, something as small as adding an id works:
 
 
 ```````````````````````````````` example
@@ -54,7 +55,7 @@ This will likely happen without notice for elements like `iframe` (say, a Youtub
 
 Here is a video:
 
-<video class="force-html"><source src='static/video.mp4 /></video>
+<video id="a-video"><source src='static/video.mp4' /></video>
 
 ````````````````````````````````
 
@@ -63,7 +64,7 @@ results in the following generated HTML:
 ```````````````````````````````` example
 <h2>Some markdown interspersed with HTML</h3>
 <p>Here is a video:</p>
-<video class="force-html"><source src='static/video.mp4 /></video>
+<video id="a-video"><source src='static/video.mp4' /></video>
 
 ````````````````````````````````
 
@@ -74,7 +75,7 @@ If you have a deeply nested HTML structure, the attribute is only required at th
 
 Here comes some nested HTML:
 
-<div class="force-html">
+<div id="nested-content">
   <p>
     Some HTML content, <em>now with emphasis.</em> And <strong>now, very strong.</strong>
   </p>

--- a/guide/using-html-in-markdown.md
+++ b/guide/using-html-in-markdown.md
@@ -20,7 +20,7 @@ From the docs:
 
 > If attached to a fenced code block, it causes the block to be interpreted as raw block content with the specified format.
 
-For HTML, this just requires adding `{=html}` after the opening ``` codeblock fence.
+For HTML, this just requires adding `{=html}` after the opening ` ``` ` codeblock fence.
 
 So, the following markdown content:
 

--- a/guide/using-html-in-markdown.md
+++ b/guide/using-html-in-markdown.md
@@ -1,0 +1,67 @@
+# Using HTML in Markdown, in Neuron
+
+Usually, Markdown supports raw HTML inline as valid Markdown syntax.
+
+Because Neuron previously used an angle-bracket syntax for linking (`<note>` would generate a link to `note.md`), when Neuron encounters a simple HTML tag in a note, it is parsed as if it were a link. This link format is now deprecated, but is still supported (see footnote on [[linking]]).
+This may be changed in the future if a reliable migration path is identified (i.e. a script that would automatically convert angle-bracket links to wiki-links).
+
+## Getting HTML to work
+
+In order to get raw HTML to work in a note, for example to embed a `<video />` element, there are two options:
+
+1. Wrap the HTML in a code-block with a 'raw-attribute', which causes the code block to be interpreted as raw inline content
+2. Add an HTML attribute to your element, like `class` or `name`, which causes Neuron to recognize that element is not a note link
+
+### Using raw-attributes to insert HTML
+
+The Haskell Commonmark interpreter supports ['raw-attributes' to cause the code in the block to be interpreted as inline](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/raw_attribute.md).
+
+From the docs:
+
+> If attached to a fenced code block, it causes the block to be interpreted as raw block content with the specified format.
+
+For HTML, this just requires adding `{=html}` after the opening ``` codeblock fence.
+
+So, the following markdown content:
+
+```````````````````````````````` example
+## Some markdown interspersed with HTML
+
+Here is a video:
+
+``` {=html}
+<video><source src='static/video.mp4 /></video>
+```
+````````````````````````````````
+
+results in the following generated HTML:
+
+```````````````````````````````` example
+<h2>Some markdown interspersed with HTML</h3>
+<p>Here is a video:</p>
+<video><source src='static/video.mp4 /></video>
+````````````````````````````````
+
+### Using HTML attributes to cause Neuron to recognize HTML elements
+
+If an HTML attribute is added to an element, Neuron ignores it while generating the link heterarchy and passes it unchanged to the Markdown parser.
+
+This will likely happen without notice for elements like `iframe` (say, a Youtube embed), since they depend heavily attribute values. For simpler elements, something as small as adding an innocuous and arbitrary class works:
+
+
+```````````````````````````````` example
+## Some markdown interspersed with HTML
+
+Here is a video:
+
+<video class="force-html"><source src='static/video.mp4 /></video>
+
+````````````````````````````````
+
+results in the following generated HTML:
+
+```````````````````````````````` example
+<h2>Some markdown interspersed with HTML</h3>
+<p>Here is a video:</p>
+<video class="force-html"><source src='static/video.mp4 /></video>
+

--- a/guide/using-html-in-markdown.md
+++ b/guide/using-html-in-markdown.md
@@ -65,3 +65,19 @@ results in the following generated HTML:
 <p>Here is a video:</p>
 <video class="force-html"><source src='static/video.mp4 /></video>
 
+````````````````````````````````
+
+If you have a deeply nested HTML structure, the attribute is only required at the top/root level:
+
+```````````````````````````````` example
+## Some markdown interspersed with HTML
+
+Here comes some nested HTML:
+
+<div class="force-html">
+  <p>
+    Some HTML content, <em>now with emphasis.</em> And <strong>now, very strong.</strong>
+  </p>
+</div>
+
+````````````````````````````````


### PR DESCRIPTION
This PR adds documentation for using HTML in Neuron markdown.

Because Neuron scans notes for links before passing them to the MD parser, and because Neuron still supports `<note-name>` link syntax, it treats simple HTML elements as notes, which result in missing/unknown note warnings.

The documentation added covers two solutions:

1. Using Commonmark raw-attribute syntax as noted in https://github.com/srid/neuron/issues/437#issuecomment-710698849
2. Adding an HTML attribute to the element

Adds documentation for #437

---

## Consideration

I discovered the option of adding HTML attrs when I was wondering why an `iframe` worked in a note without the raw-attribute syntax, but `video` didn't. It has worked for every basic HTML element I've tried to use it for without issue.

The upside, is that the Markdown is more idiomatic, and less tied to Commonmark. The downside is the proliferation of classes/attributes. However, the attribute only appears to be required on the outmost HTML element of a block.
