### PR TITLE
Exclude punctuation from inline tag parse

### DIFF
--- a/neuron/src/lib/Neuron/Reader/Markdown.hs
+++ b/neuron/src/lib/Neuron/Reader/Markdown.hs
@@ -223,7 +223,9 @@ wikiLinkSpec =
 
 inlineTagP :: Monad m => P.ParsecT [CM.Tok] s m [CM.Tok]
 inlineTagP =
-  some (noneOfToks [Symbol ']', Symbol ',', Symbol '.', Spaces, UnicodeSpace, LineEnd])
+  some (noneOfToks $ [Spaces, UnicodeSpace, LineEnd] <> fmap Symbol punctuation)
+  where
+    punctuation = "[];:,.?!"
 
 -- rawHtmlSpec eats angle bracket links as html tags
 defaultBlockSpecsSansRawHtml :: (Monad m, CM.IsBlock il bl) => [CM.BlockSpec m il bl]

--- a/neuron/src/lib/Neuron/Reader/Markdown.hs
+++ b/neuron/src/lib/Neuron/Reader/Markdown.hs
@@ -223,7 +223,7 @@ wikiLinkSpec =
 
 inlineTagP :: Monad m => P.ParsecT [CM.Tok] s m [CM.Tok]
 inlineTagP =
-  some (noneOfToks [Symbol ']', Spaces, UnicodeSpace, LineEnd])
+  some (noneOfToks [Symbol ']', Symbol ',', Symbol '.', Spaces, UnicodeSpace, LineEnd])
 
 -- rawHtmlSpec eats angle bracket links as html tags
 defaultBlockSpecsSansRawHtml :: (Monad m, CM.IsBlock il bl) => [CM.BlockSpec m il bl]

--- a/neuron/test/Neuron/Zettelkasten/Zettel/ParserSpec.hs
+++ b/neuron/test/Neuron/Zettelkasten/Zettel/ParserSpec.hs
@@ -31,6 +31,12 @@ spec = do
     it "hierarchical" $ do
       let z :: Zettel = parseSomeZettel "An #foo/bar/baz tag"
       zettelTags z `shouldBe` [Tag "foo/bar/baz"]
+    it "followed by punctuation" $ do
+      let z :: Zettel = parseSomeZettel "A #tag; with content"
+      zettelTags z `shouldBe` [Tag "tag"]
+    it "followed by different punctuation" $ do
+      let z :: Zettel = parseSomeZettel "A #tag? With content"
+      zettelTags z `shouldBe` [Tag "tag"]
     it "allows URLs with a hash" $ do
       pendingWith "#397"
       let z :: Zettel = parseSomeZettel "Some http://www.google.com/#foo url"


### PR DESCRIPTION
Resolves #441

I was thinking about something a little more extensible, e.g.

```haskell
some (noneOfToks $ [Spaces, UnicodeSpace, LineEnd] <> fmap Symbol excludedChars)
where excludedChars = "],."
```

but I figured this list probably won't be growing or changing much, and I figured the simple/ expanded version I'm proposing reads a little more smoothly. Let me know if you have a preference one way or the other! (Also please let me know if any other characters should be excluded from the parse.)