### PR TITLE
make search include zettel with no explicit title, use filename instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
-- Revert #429 for neuron-search regression
 - Fix search.html to handle zettels with title IDs (with whitespace) (#438)
 - Ignore punctuation in inline tags (#443)
+- `neuron search`
+  - Revert #429 for neuron-search regression
+  - Deal with title IDs in search (#445)
 
 ## 1.0.1.0
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 1.0.5.0
+version: 1.0.6.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -8,6 +8,8 @@ EXTENSIONS=${4}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${5})
 cd ${NOTESDIR}
 
+# The LC_ALL here is fix the "illegal byte sequence" error
+# See https://github.com/srid/neuron/pull/445#discussion_r513066111
 {    rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
   && rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
      --files-without-match | awk '{ printf "%s:!title: %s\n", $0, $0}'; } \

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -8,10 +8,13 @@ EXTENSIONS=${4}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${5})
 cd ${NOTESDIR}
 
-{ ls *.md | awk '{ printf "%s:!title: %s\n", $0, $0}' && rg --no-heading --no-line-number --with-filename "${FILTERBY}" -g "${EXTENSIONS}"; } | sort -t: -k1,2 -r | sort -t: -k1,1 -u \
+{    rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
+  && rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
+     --files-without-match | awk '{ printf "%s:!title: %s\n", $0, $0}'; } \
+  | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,2 -r || cat ) \
+  | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,1 -u || cat )\
   | fzf --tac --no-sort -d ':' -n ${SEARCHFROMFIELD}.. \
     --preview 'bat --style=plain --color=always {1}' \
   | awk -F: "{printf \"${NOTESDIR}/%s\", \$1}" \
   | xargs -I % ${OPENCMD} %
 
-#  rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -7,8 +7,11 @@ SEARCHFROMFIELD=${3}
 EXTENSIONS=${4}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${5})
 cd ${NOTESDIR}
-rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
+
+{ ls *.md | awk '{ printf "%s:!title: %s\n", $0, $0}' && rg --no-heading --no-line-number --with-filename "${FILTERBY}" -g "${EXTENSIONS}"; } | sort -t: -k1,2 -r | sort -t: -k1,1 -u \
   | fzf --tac --no-sort -d ':' -n ${SEARCHFROMFIELD}.. \
     --preview 'bat --style=plain --color=always {1}' \
   | awk -F: "{printf \"${NOTESDIR}/%s\", \$1}" \
-  | xargs -r ${OPENCMD}
+  | xargs -I % ${OPENCMD} %
+
+#  rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \


### PR DESCRIPTION
I "hacked" `neuron/src-bash/neuron-search` to include all zettel, also those that previously were not listed because they don't have an explicit `title: ` in the header, nor a `# <title>` line. 

I have many "legacy" zettel imported from iA writer, Ulysses, nvAlt and such where the convention was to use `## <title>` to generate filename etc. Currently they don't show up in the `neuron search` function. That's really not good. 

I think the `neuron` convention is to use the filename as title if there is none specified, which this PR takes care of.

It's a bit of a kludge, but it seems to work fine. Maybe someone with more `bash` expertise can clean it up later. 

Also changed the `xarg` call to deal with filenames that contain blanks. 