### PR TITLE
Allow for a newer nixpkgs, and bump nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "990af061bc84d7410a989ce0ce53d165ef51eae2",
-        "sha256": "0wmsvmgcfsq6102avnd7jgv0gaq3ics29449iwafyn7k4ysmji26",
+        "rev": "d390372c1964fdc5e18676ead1c87b646b2d4b58",
+        "sha256": "0v8mlh4m6c1zriq2g2a4559aqaqy6rwr2xxl9hdzy0nnijhzlii0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/990af061bc84d7410a989ce0ce53d165ef51eae2.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d390372c1964fdc5e18676ead1c87b646b2d4b58.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-static": {

--- a/project.nix
+++ b/project.nix
@@ -52,9 +52,9 @@ let
     reflex-dom-pandoc =
       pkgs.haskell.lib.dontHaddock (self.callCabal2nix "reflex-dom-pandoc" sources.reflex-dom-pandoc { });
 
-    # This version is not the default in nixpkgs, yet.
-    skylighting = super.skylighting_0_10_0_2;
-    skylighting-core = super.skylighting-core_0_10_0_2;
+    # This version is not the default in the static nixpkgs, yet.
+    skylighting = super.skylighting_0_10_0_2 or super.skylighting;
+    skylighting-core = super.skylighting-core_0_10_0_2 or super.skylighting-core;
     # Jailbreak pandoc to work with newer skylighting
     pandoc = doJailbreak (dontCheck super.pandoc);
 


### PR DESCRIPTION
Edit, because I forgot the context: Hey there! I'm install neuron in my own flake-based setup, where I try to use a single nixpkgs if possible. I had to make a few changes to upgrade it to the latest nixpkgs, so I though I'd send them here.

I modified the skylighting pinning to work on newer nixpkgs versions where 0.10.0.2 doesn't exist, and 0.10.0.3 is the default.

I bumped nixpkgs while I was at it, but feel free to drop that commit if you don't want it upgraded.

I didn't touch the static nixpkgs, because I couldn't run it on my osx setup, thus I ensured to keep the changes backward-compatible.
