### PR TITLE
Fix more parsing issues with pipe characters

### DIFF
--- a/neuron/src/lib/Neuron/Reader/Markdown.hs
+++ b/neuron/src/lib/Neuron/Reader/Markdown.hs
@@ -130,13 +130,15 @@ neuronSpec =
       CE.rawAttributeSpec,
       CE.fencedDivSpec,
       CE.bracketedSpanSpec,
-      CM.defaultSyntaxSpec
+      CM.defaultSyntaxSpec,
+      -- as the commonmark documentation states, pipeTableSpec should be placed after
+      -- fancyListSpec and defaultSyntaxSpec to avoid bad results when non-table lines
+      CE.pipeTableSpec
     ]
   where
     -- Emoji extension introduces ghcjs linker issues
     gfmExtensionsSansEmoji =
       CE.strikethroughSpec
-        <> CE.pipeTableSpec
         <> CE.autoIdentifiersSpec
         <> CE.taskListSpec
 


### PR DESCRIPTION
`pipeTableSpec` should also be after `defaultSyntaxSpec`

Fixes #469 & fixes #465 