### PR TITLE
Fix for org-mode folgezettel links

### DIFF
--- a/neuron/src/app/Neuron/Reader/Org.hs
+++ b/neuron/src/app/Neuron/Reader/Org.hs
@@ -15,22 +15,35 @@ where
 import qualified Data.Map as Map
 import Data.TagTree (Tag (Tag))
 import Data.Tagged
-import Data.Text (toLower)
+import Data.Text (append, isSuffixOf, toLower)
 import Data.Time.DateMayTime (DateMayTime, parseDateMayTime)
 import Neuron.Reader.Type (ZettelParseError, ZettelReader)
 import Neuron.Zettelkasten.Zettel.Meta (Meta (..))
 import Relude
 import Relude.Extra.Map (lookup)
 import Text.Pandoc (def, runPure)
-import Text.Pandoc.Definition (Pandoc)
+import Text.Pandoc.Definition (Inline(Link), Pandoc)
 import Text.Pandoc.Readers.Org (readOrg)
 import Text.Pandoc.Util (getH1)
+import Text.Pandoc.Walk (walk)
 
 parseOrg :: ZettelReader
 parseOrg _ s = do
   doc <- first show $ runPure $ readOrg def s
+  docWithChanges <- pure $ changeLinkTypes doc
   meta <- extractMetadata doc
-  pure (meta, doc)
+  pure (meta, docWithChanges)
+
+-- | Modifies links parsing to that pandoc AST has type/branch parameters
+changeLinkTypes :: Pandoc -> Pandoc
+changeLinkTypes = walk modLink
+  where
+    modLink:: Inline -> Inline
+    modLink (Link a b t) = Link a b (replaceTarget t)
+    modLink x = x
+    replaceTarget (url, title)
+      | not $ isSuffixOf "?cf" url = (append url "?type=branch", title)
+      | otherwise                  = (url , title)
 
 -- | Extract metadata from the properties that are attached to the first headline
 extractMetadata :: Pandoc -> Either ZettelParseError (Maybe Meta)

--- a/neuron/src/app/Neuron/Reader/Org.hs
+++ b/neuron/src/app/Neuron/Reader/Org.hs
@@ -22,7 +22,7 @@ import Neuron.Zettelkasten.Zettel.Meta (Meta (..))
 import Relude
 import Relude.Extra.Map (lookup)
 import Text.Pandoc (def, runPure)
-import Text.Pandoc.Definition (Inline(Link), Pandoc)
+import Text.Pandoc.Definition (Inline (Link), Pandoc)
 import Text.Pandoc.Readers.Org (readOrg)
 import Text.Pandoc.Util (getH1)
 import Text.Pandoc.Walk (walk)
@@ -38,12 +38,12 @@ parseOrg _ s = do
 changeLinkTypes :: Pandoc -> Pandoc
 changeLinkTypes = walk modLink
   where
-    modLink:: Inline -> Inline
+    modLink :: Inline -> Inline
     modLink (Link a b t) = Link a b (replaceTarget t)
     modLink x = x
     replaceTarget (url, title)
       | not $ isSuffixOf "?cf" url = (append url "?type=branch", title)
-      | otherwise                  = (url , title)
+      | otherwise = (url, title)
 
 -- | Extract metadata from the properties that are attached to the first headline
 extractMetadata :: Pandoc -> Either ZettelParseError (Maybe Meta)


### PR DESCRIPTION
As described in #480 , I wasn't able to get folgezettel links to work with org-mode formatted Zetteln