### PR TITLE
Add guide for custom javaScript actions.

### DIFF
--- a/guide/chartjs.md
+++ b/guide/chartjs.md
@@ -1,0 +1,99 @@
+---
+title: "Chart.js"
+---
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.min.js" integrity="sha512-SuxO9djzjML6b9w9/I07IWnLnQhgyYVSpHZx0JV97kGBfTIsUYlWflyuW4ypnvhBrslz1yJ3R+S14fdCWmSmSA==" crossorigin="anonymous"></script>
+<script>
+window.addEventListener("load", function(){
+  for (let element of document.getElementsByClassName("chartjs")) {
+    let parent = element.parentNode
+    let pparent = parent.parentNode
+    let canvas = document.createElement('canvas');
+    let box = document.createElement('div');
+    box.appendChild(canvas);
+    let ctx = canvas.getContext("2d")
+    let myChart = new Chart(ctx, JSON.parse(element.textContent));
+    box.setAttribute("style","display:block;width:75%;text-align:'center';margin: 5px auto;");
+    pparent.replaceChild(box, parent)
+  }
+});
+</script>
+
+[Chart.js](https://www.chartjs.org/docs/latest/charts/mixed.html)
+
+```{.chartjs}
+{"type":"bar","data":{"labels":["January","February","March","April"],"datasets":[{"label":"Bar Dataset","data":[10,20,30,40],"borderColor":"rgb(255, 99, 132)","backgroundColor":"rgba(255, 99, 132, 0.2)"},{"label":"Line Dataset","data":[50,50,50,50],"type":"line","fill":false,"borderColor":"rgb(54, 162, 235)"}]},"options":{"scales":{"yAxes":[{"ticks":{"beginAtZero":true}}]}}}
+```
+
+HTML
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.min.js" integrity="sha512-SuxO9djzjML6b9w9/I07IWnLnQhgyYVSpHZx0JV97kGBfTIsUYlWflyuW4ypnvhBrslz1yJ3R+S14fdCWmSmSA==" crossorigin="anonymous"></script>
+<script>
+window.addEventListener("load", function(){
+  for (let element of document.getElementsByClassName("chartjs")) {
+    let parent = element.parentNode
+    let pparent = parent.parentNode
+    let canvas = document.createElement('canvas');
+    let box = document.createElement('div');
+    box.appendChild(canvas);
+    let ctx = canvas.getContext("2d")
+    let myChart = new Chart(ctx, JSON.parse(element.textContent));
+    box.setAttribute("style","display:block;width:75%;text-align:'center';margin: 5px auto;");
+    pparent.replaceChild(box, parent)
+  }
+});
+</script>
+```
+
+Markdown
+~~~markdown
+```chartjs
+{
+  "type": "bar",
+  "data": {
+    "labels": [
+      "January",
+      "February",
+      "March",
+      "April"
+    ],
+    "datasets": [
+      {
+        "label": "Bar Dataset",
+        "data": [
+          10,
+          20,
+          30,
+          40
+        ],
+        "borderColor": "rgb(255, 99, 132)",
+        "backgroundColor": "rgba(255, 99, 132, 0.2)"
+      },
+      {
+        "label": "Line Dataset",
+        "data": [
+          50,
+          50,
+          50,
+          50
+        ],
+        "type": "line",
+        "fill": false,
+        "borderColor": "rgb(54, 162, 235)"
+      }
+    ]
+  },
+  "options": {
+    "scales": {
+      "yAxes": [
+        {
+          "ticks": {
+            "beginAtZero": true
+          }
+        }
+      ]
+    }
+  }
+}
+```
+~~~

--- a/guide/graphviz.md
+++ b/guide/graphviz.md
@@ -1,0 +1,85 @@
+---
+title: "Graphviz"
+---
+
+[Graphviz](https://graphviz.org/)
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/viz.js" integrity="sha512-vnRdmX8ZxbU+IhA2gLhZqXkX1neJISG10xy0iP0WauuClu3AIMknxyDjYHEpEhi8fTZPyOCWgqUCnEafDB/jVQ==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/full.render.js" integrity="sha512-1zKK2bG3QY2JaUPpfHZDUMe3dwBwFdCDwXQ01GrKSd+/l0hqPbF+aak66zYPUZtn+o2JYi1mjXAqy5mW04v3iA==" crossorigin="anonymous"></script>
+<script>
+window.addEventListener("load", function(){
+  let viz = new Viz();
+  for (let element of document.getElementsByClassName("graphviz")) {
+    let parent = element.parentNode
+    let pparent = parent.parentNode
+    viz.renderSVGElement(element.textContent)
+    .then(function(element) {
+      element.setAttribute("width", "100%")
+      pparent.replaceChild(element, parent)
+    });
+  }
+});
+</script>
+
+HTML
+```{.graphviz}
+digraph G {
+
+	subgraph cluster_0 {
+		style=filled;
+		color=lightgrey;
+		node [style=filled,color=white];
+		a0 -> a1 -> a2 -> a3;
+		label = "process #1";
+	}
+
+	subgraph cluster_1 {
+		node [style=filled];
+		b0 -> b1 -> b2 -> b3;
+		label = "process #2";
+		color=blue
+	}
+	start -> a0;
+	start -> b0;
+	a1 -> b3;
+	b2 -> a3;
+	a3 -> a0;
+	a3 -> end;
+	b3 -> end;
+
+	start [shape=Mdiamond];
+	end [shape=Msquare];
+}
+```
+
+Markdown
+~~~markdown
+```{.graphviz}
+digraph G {
+
+	subgraph cluster_0 {
+		style=filled;
+		color=lightgrey;
+		node [style=filled,color=white];
+		a0 -> a1 -> a2 -> a3;
+		label = "process #1";
+	}
+
+	subgraph cluster_1 {
+		node [style=filled];
+		b0 -> b1 -> b2 -> b3;
+		label = "process #2";
+		color=blue
+	}
+	start -> a0;
+	start -> b0;
+	a1 -> b3;
+	b2 -> a3;
+	a3 -> a0;
+	a3 -> end;
+	b3 -> end;
+
+	start [shape=Mdiamond];
+	end [shape=Msquare];
+}
+```

--- a/guide/mermaid-js.md
+++ b/guide/mermaid-js.md
@@ -1,0 +1,37 @@
+---
+title: "mermaid-js"
+---
+
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>
+window.addEventListener("load", mermaid.initialize({startOnLoad:true}))
+</script>
+
+[mermaid-js](https://mermaid-js.github.io/mermaid/#/)
+
+```{.mermaid}
+sequenceDiagram
+    Alice->>John: Hello John, how are you?
+    activate John
+    John-->>Alice: Great!
+    deactivate John
+```
+
+HTML
+```html
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>
+window.addEventListener("load", mermaid.initialize({startOnLoad:true}))
+</script>
+```
+
+Markdown
+~~~markdown
+```{.mermaid}
+sequenceDiagram
+    Alice->>John: Hello John, how are you?
+    activate John
+    John-->>Alice: Great!
+    deactivate John
+```
+~~~


### PR DESCRIPTION
Adding some guide for client-side rendering tricks we can use with neruon.
As all of it is implemented with similar logic, 
I think it would be better to write an integration guide at the "master node" explaining that you can use it with "head.html" or raw html inside each zettel.

All 3 Zettels only include code and examples. 