### PR TITLE
[DOCS] Explain rationale for lifting subdir notes out of hierarchy

### DIFF
--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -10,9 +10,9 @@ The *Directory Tree* plugin automatically creates a [[folgezettel-heterarchy]] r
 
 ## Directory Zettel
 
-Given a folder `./Project/HouseWarming/`, this plugin will create two zettels with [[id]] `Project` and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
+Given a file `./Home/Projects/HouseWarming.md` this plugin will create three zettels with [[id]] `Home`, `Project` and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
 
-Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `family/notes` and `work/notes` will cause Neuron to attempt to generate two zettels with the ID `notes`, which will cause an error. In order to resolve this error, and to keep the zettel IDs [[atomic]], it would be better to rename **both** notes to `work/work-notes/` and `family/family-notes`.
+Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `./Home/Projects/HouseWarming` and `./Work/Projects/FireZeMissiles` will cause Neuron to attempt to generate two zettels with the ID `Projects`, which will cause an error. In order to resolve this error, and to keep the zettel IDs [[atomic]], it would be better to rename **both** notes to `./Home/HomeProjects/` and `./Work/WorkProjects/`.
 
 The zettel content for directory zettels are by default empty. However, you may explicitly specify them by creating zettel files using the same [[id]]; for the example above, you may create `./Project.md` and `./Project/HouseWarming.md` - and they will be "merged" to the auto-created directory zettels.
 

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -10,7 +10,7 @@ The *Directory Tree* plugin automatically creates a [[folgezettel-heterarchy]] r
 
 ## Using and creating Directory Zettels
 
-Given a file `./Home/Projects/HouseWarming.md` this plugin will create three zettels with [[id]] `Home`, `Project` and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
+Given a file `./Home/Projects/HouseWarming.md` this plugin will create three zettels with [[id]]s `Home`, `Projects`, and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
 
 Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `./Home/Projects/HouseWarming` and `./Work/Projects/FireZeMissiles` will cause Neuron to attempt to generate two zettels with the ID `Projects`, which will cause an error. In order to resolve this error, and to keep the zettel IDs [[atomic]], it would be better to rename **both** notes to `./Home/HomeProjects/` and `./Work/WorkProjects/`.
 
@@ -25,7 +25,9 @@ The zettel content for directory zettels are by default empty, only showing a li
   ├── HomeProjects/        # HomeProjects **directory** zettel
   │   └── HouseWarming.md
   └── HomeProjects.md      # Note whose content will be merged into the HomeProjects **directory** zettel
+```
 
+```
 # Generated HTML notes
 
 - Home.html
@@ -59,9 +61,62 @@ directories around to provide context. The example from before,
 (The other reason it is good to have unique IDs is to avoid ID clash, as covered
 above.)
 
+### Automatically created folgezettel heterarchies
+
+Even though the on-disk directory structure is discarded, the information it
+carries is preserved by Neuron when it creates a [[folgezettel-heterarchy]]
+between a Directory Zettel and its child notes/contents.
+
+Putting the `HomeProjects.md` zettel inside the `Home/` folder creates
+a parent-to-child folgezettel relationship from `Home` to `HomeProjects`, _as if you had a `Home.md` note that included a folgezettel
+link to `HomeProjects.md` in its content_.
+
+This structure
+
+```
+└─Home/
+  └── HomeProjects.md
+```
+
+creates a relationship equivalent to that created by these two notes, side by side, with a folgezettel link from the `Home.md` note to the `HomeProjects.md` note:
+
+```
+# ./Home.md
+---
+date: 2020-12-31
+---
+
+# Home
+
+I'm working on some [[[HomeProjects]]] right now.
+```
+
+```
+# ./HomeProjects.md
+---
+date: 2020-12-31
+---
+
+# Home Projects
+
+- fix the leaky faucet
+- paint the bathroom
+```
+
+
+
+#### The **Directory Tree** plugin only triggers on folders inside the Neuron project
+
+When enabled, the plugin will only work on the subfolders it finds **inside** the
+Neuron project. This means that it will **not** automatically create a
+[[folgezettel-heterarchy]] from the `index` of your project to every
+zettel in the project (whether you have an
+explicit `index.md` zettel or just rely on Neuron's [[impulse-feature]] as your
+home)[^man].
+
 ### Creating links and heterarchies outside the directory
 
-This also means that you can link and create any [[folgezettel-heterarchy]] you
+Directory Zettles just being normal zettels also means that you can link and create any [[folgezettel-heterarchy]] you
 like with the zettels created from directory trees. For example, we could create
 a new zettel called `Projects.md` at the 'top' of our Neuron project, to gather
 together all of our more focused project zettels, as a sort of gateway:
@@ -77,9 +132,10 @@ together all of our more focused project zettels, as a sort of gateway:
    ├── HomeProjects/
    │   └── HouseWarming.md
    └── HomeProjects.md
+```
 
+```
 # ./Projects.md
-
 ---
 date: 2020-12-31
 tags:
@@ -92,13 +148,11 @@ tags:
 Right now, my [[[WorkProjects]]] are taking most of
 my focus and energy, and not leaving much time to focus
 on my [[[HomeProjects]]].
-
-
 ```
 
 ### Automatically created tags
 
-In addition to creating automatic a [[folgezettel-heterarchy] for each
+In addition to creating automatic a [[folgezettel-heterarchy]] for each
 directory, the plugin also [[tags]] the notes with their on-disk path, up to, but
 **not including** their own ID. So the note at
 `./Home/HomeProjects/HouseWarming.md` would get the **hierarchical** tag
@@ -119,20 +173,14 @@ Given our work-and-home project:
 notes would be generated with these hierarchical tags that match their folder
 path:
 
-```
-# Note                    # Tag
+| Note                  | Tag                       |
+|-----------------------|---------------------------|
+| `Work.html`           | `#root`                   |
+| `WorkProjects.html`   | `#root/Work`              |
+| `FireZeMissiles.html` | `#root/Work/WorkProjects` |
+| `Home.html`           | `#root`                   |
+| `HomeProjects.html`   | `#root/Home`              |
+| `HouseWarming.html`   | `#root/Home/HomeProjects` |
 
-- Work.html               #root
-- WorkProjects.html       #root/Work
-- FireZeMissiles.html     #root/Work/WorkProjects
-- Home.html               #root
-- HomeProjects.html       #root/Home
-- HouseWarming.html       #root/Home/HomeProjects
-```
-
-## Links & tags created
-
-A [[folgezettel-heterarchy]] is formed, reflecting the directory tree on disk, with the exception of the `index` zettel[^man]. The forming of links is based on hierarchical [[tags]] (reflecting the relative path), that every normal zettel and directory zettel is automatically tagged with.
-
-[^man]: You may manually form these relationships by adding `[[[z:zettels?tag=root]]]` to the top-level `index.md`
+[^man]: You may manually form these relationships by adding `[[[z:zettels?tag=root]]]` to the top-level `index.md`, since all the generated Directory Zettels are tagged with `#root`
 

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -130,37 +130,6 @@ path:
 - HouseWarming.html       #root/Home/HomeProjects
 ```
 
-
-
-### Generated notes are 'lifted' out of their directory hierarchy
-
-Notes whose files are located in a subdirectory, will be 'lifted' to the same level as the 'root'--at the same level as their parents and grandparents.
-
-For example, the following directory structure
-
-```
-└─programming
-  ├── ruby.md
-  ├── ruby
-  │   ├── rails.md
-  │   └── rspec-testing.md
-  └── functional-programming.md
-```
-
-would create the following HTML documents, all at the top-level of the generated Neuron site: 
-
-- `programming.html`
-- `ruby.html`
-- `rails.html`
-- `rspec-testing.html`
-- `functional-programming.html`
-
-Because a directory's name will become its zettel ID, and because all zettels are 'lifted' out of their path hierarchy when notes are generated, it is important to give it a clear and meaningful name (if you are using non-random IDs). 
-
-A zettel created by the directory `work/notes` is a bad zettel ID, because once at the 'top' level of the zettelkasten, the ID `notes` has lost the context provided by its parent directory. A better ID would be `work/work-notes`.
-
-While this might seem redundant at first glance, the rationale for this this lift is to keep the zettels [[atomic]], and to keep linking as simple as possible. To link to the `work-notes` zettel, you don't need to remember that it's in the `work/` directory--you just link to `[[work-notes]]`. And if you choose to move it in the future, you don't need to hunt down and remember to update links that have been made to it.
-
 ## Links & tags created
 
 A [[folgezettel-heterarchy]] is formed, reflecting the directory tree on disk, with the exception of the `index` zettel[^man]. The forming of links is based on hierarchical [[tags]] (reflecting the relative path), that every normal zettel and directory zettel is automatically tagged with.

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -8,13 +8,34 @@ The *Directory Tree* plugin automatically creates a [[folgezettel-heterarchy]] r
 2. Tag every zettel with a hierarchical [[tags]] (`root/**`) corresponding to its path
 3. Create folgezettel links (see [[linking]]) automatically reflecting the directory tree
 
-## Directory Zettel
+## Using and creating Directory Zettels
 
 Given a file `./Home/Projects/HouseWarming.md` this plugin will create three zettels with [[id]] `Home`, `Project` and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
 
 Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `./Home/Projects/HouseWarming` and `./Work/Projects/FireZeMissiles` will cause Neuron to attempt to generate two zettels with the ID `Projects`, which will cause an error. In order to resolve this error, and to keep the zettel IDs [[atomic]], it would be better to rename **both** notes to `./Home/HomeProjects/` and `./Work/WorkProjects/`.
 
-The zettel content for directory zettels are by default empty. However, you may explicitly specify them by creating zettel files using the same [[id]]; for the example above, you may create `./Project.md` and `./Project/HouseWarming.md` - and they will be "merged" to the auto-created directory zettels.
+### Adding content to a Directory Zettel
+
+The zettel content for directory zettels are by default empty, only showing a list of links to its contents. However, you may explicitly specify them by creating zettel files using the same [[id]]; for the example above, you may create `./HomeProjects.md`- and it will be "merged" to the auto-created directory zettel:
+
+```
+# Directory structure
+
+└─Home/
+  ├── HomeProjects/        # HomeProjects **directory** zettel
+  │   └── HouseWarming.md
+  └── HomeProjects.md      # Note whose content will be merged into the HomeProjects **directory** zettel
+
+# Generated HTML notes
+
+- Home.html
+- HomeProjects.html
+- HouseWarming.html
+```
+
+No addtional zettels are generated, but any content in the `HomeProjects.md`
+file will be shown in the generated `HomeProjects.html` file in the [[web]].
+
 
 ### Generated notes are 'lifted' out of their directory hierarchy
 

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -36,6 +36,101 @@ The zettel content for directory zettels are by default empty, only showing a li
 No addtional zettels are generated, but any content in the `HomeProjects.md`
 file will be shown in the generated `HomeProjects.html` file in the [[web]].
 
+## Directory Zettels are normal zettels
+
+When Neuron is configured to use the **Directory Tree** plugin, it looks for all
+the markdown files in your repository, regardless of how many folders deep they
+are (unless you are using the [[Ignoring files]] plugin).
+
+The directory structure you have on disk is used to do 2 things:
+
+- automatically create a [[folgezettel-heterarchy]] from a directory zettel with
+    the zettels for its contents
+- automatically tag the zettels created with their on-disk path
+
+Once Neuron generates the [[zettelkasten]], the directory structure is
+discarded from memory and not used in the [[web]]. All of the generated notes are made accessible at the 'top' level of the generated site--you don't need to navigate down the on-disk directory structure in the [[web]].
+
+This is one reason why it's good practice to give your directories an [[atomic]]
+[[id]]--once you've generated your zettelkasten, you no longer have the parent
+directories around to provide context. The example from before,
+`./Home/Projects`, would create a note for your home projects with the ID
+`Projects`--we can no longer tell that it is specifically **home** projects.
+(The other reason it is good to have unique IDs is to avoid ID clash, as covered
+above.)
+
+### Creating links and heterarchies outside the directory
+
+This also means that you can link and create any [[folgezettel-heterarchy]] you
+like with the zettels created from directory trees. For example, we could create
+a new zettel called `Projects.md` at the 'top' of our Neuron project, to gather
+together all of our more focused project zettels, as a sort of gateway:
+
+```
+# Directory structure
+
+├── Projects.md
+├── Work/
+│   └── WorkProjects/
+│      └── FireZeMissiles.md
+└─ Home/
+   ├── HomeProjects/
+   │   └── HouseWarming.md
+   └── HomeProjects.md
+
+# ./Projects.md
+
+---
+date: 2020-12-31
+tags:
+  - work
+  - home
+---
+
+# All Projects
+
+Right now, my [[[WorkProjects]]] are taking most of
+my focus and energy, and not leaving much time to focus
+on my [[[HomeProjects]]].
+
+
+```
+
+### Automatically created tags
+
+In addition to creating automatic a [[folgezettel-heterarchy] for each
+directory, the plugin also [[tags]] the notes with their on-disk path, up to, but
+**not including** their own ID. So the note at
+`./Home/HomeProjects/HouseWarming.md` would get the **hierarchical** tag
+`#root/Home/HomeProjects`. These tags always start at the `#root` tag.
+
+Given our work-and-home project:
+
+```
+├── Work/
+│   └── WorkProjects/
+│      └── FireZeMissiles.md
+└─ Home/
+   ├── HomeProjects/
+   │   └── HouseWarming.md
+   └── HomeProjects.md
+```
+
+notes would be generated with these hierarchical tags that match their folder
+path:
+
+```
+# Note                    # Tag
+
+- Work.html               #root
+- WorkProjects.html       #root/Work
+- FireZeMissiles.html     #root/Work/WorkProjects
+- Home.html               #root
+- HomeProjects.html       #root/Home
+- HouseWarming.html       #root/Home/HomeProjects
+```
+
+
 
 ### Generated notes are 'lifted' out of their directory hierarchy
 

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -35,41 +35,26 @@ The zettel content for directory zettels are by default empty, only showing a li
 - HouseWarming.html
 ```
 
-No addtional zettels are generated, but any content in the `HomeProjects.md`
-file will be shown in the generated `HomeProjects.html` file in the [[web]].
+No addtional zettels are generated, but any content in the `HomeProjects.md` file will be shown in the generated `HomeProjects.html` file in the [[web]].
 
 ## Directory Zettels are normal zettels
 
-When Neuron is configured to use the **Directory Tree** plugin, it looks for all
-the markdown files in your repository, regardless of how many folders deep they
-are (unless you are using the [[Ignoring files]] plugin).
+When Neuron is configured to use the **Directory Tree** plugin, it looks for all the markdown files in your repository, regardless of how many folders deep they are (unless you are using the [[Ignoring files]] plugin).
 
 The directory structure you have on disk is used to do 2 things:
 
-- automatically create a [[folgezettel-heterarchy]] from a directory zettel with
-    the zettels for its contents
+- automatically create a [[folgezettel-heterarchy]] from a directory zettel with the zettels for its contents
 - automatically tag the zettels created with their on-disk path
 
-Once Neuron generates the [[zettelkasten]], the directory structure is
-discarded from memory and not used in the [[web]]. All of the generated notes are made accessible at the 'top' level of the generated site--you don't need to navigate down the on-disk directory structure in the [[web]].
+Once Neuron generates the [[zettelkasten]], the directory structure is discarded from memory and not used in the [[web]]. All of the generated notes are made accessible at the 'top' level of the generated site--you don't need to navigate down the on-disk directory structure in the [[web]].
 
-This is one reason why it's good practice to give your directories an [[atomic]]
-[[id]]--once you've generated your zettelkasten, you no longer have the parent
-directories around to provide context. The example from before,
-`./Home/Projects`, would create a note for your home projects with the ID
-`Projects`--we can no longer tell that it is specifically **home** projects.
-(The other reason it is good to have unique IDs is to avoid ID clash, as covered
-above.)
+This is one reason why it's good practice to give your directories an [[atomic]] [[id]]--once you've generated your zettelkasten, you no longer have the parent directories around to provide context. The example from before, `./Home/Projects`, would create a note for your home projects with the ID `Projects`--we can no longer tell that it is specifically **home** projects. (The other reason it is good to have unique IDs is to avoid ID clash, as covered above.)
 
 ### Automatically created folgezettel heterarchies
 
-Even though the on-disk directory structure is discarded, the information it
-carries is preserved by Neuron when it creates a [[folgezettel-heterarchy]]
-between a Directory Zettel and its child notes/contents.
+Even though the on-disk directory structure is discarded, the information it carries is preserved by Neuron when it creates a [[folgezettel-heterarchy]] between a Directory Zettel and its child notes/contents.
 
-Putting the `HomeProjects.md` zettel inside the `Home/` folder creates
-a parent-to-child folgezettel relationship from `Home` to `HomeProjects`, _as if you had a `Home.md` note that included a folgezettel
-link to `HomeProjects.md` in its content_.
+Putting the `HomeProjects.md` zettel inside the `Home/` folder creates a parent-to-child folgezettel relationship from `Home` to `HomeProjects`, _as if you had a `Home.md` note that included a folgezettel link to `HomeProjects.md` in its content_.
 
 This structure
 
@@ -107,19 +92,11 @@ date: 2020-12-31
 
 #### The **Directory Tree** plugin only triggers on folders inside the Neuron project
 
-When enabled, the plugin will only work on the subfolders it finds **inside** the
-Neuron project. This means that it will **not** automatically create a
-[[folgezettel-heterarchy]] from the `index` of your project to every
-zettel in the project (whether you have an
-explicit `index.md` zettel or just rely on Neuron's [[impulse-feature]] as your
-home)[^man].
+When enabled, the plugin will only work on the subfolders it finds **inside** the Neuron project. This means that it will **not** automatically create a [[folgezettel-heterarchy]] from the `index` of your project to every zettel in the project (whether you have an explicit `index.md` zettel or just rely on Neuron's [[impulse-feature]] as your home)[^man].
 
 ### Creating links and heterarchies outside the directory
 
-Directory Zettles just being normal zettels also means that you can link and create any [[folgezettel-heterarchy]] you
-like with the zettels created from directory trees. For example, we could create
-a new zettel called `Projects.md` at the 'top' of our Neuron project, to gather
-together all of our more focused project zettels, as a sort of gateway:
+Directory Zettles just being normal zettels also means that you can link and create any [[folgezettel-heterarchy]] you like with the zettels created from directory trees. For example, we could create a new zettel called `Projects.md` at the 'top' of our Neuron project, to gather together all of our more focused project zettels, as a sort of gateway:
 
 ```
 # Directory structure
@@ -152,11 +129,7 @@ on my [[[HomeProjects]]].
 
 ### Automatically created tags
 
-In addition to creating automatic a [[folgezettel-heterarchy]] for each
-directory, the plugin also [[tags]] the notes with their on-disk path, up to, but
-**not including** their own ID. So the note at
-`./Home/HomeProjects/HouseWarming.md` would get the **hierarchical** tag
-`#root/Home/HomeProjects`. These tags always start at the `#root` tag.
+In addition to creating automatic a [[folgezettel-heterarchy]] for each directory, the plugin also [[tags]] the notes with their on-disk path, up to, but **not including** their own ID. So the note at `./Home/HomeProjects/HouseWarming.md` would get the **hierarchical** tag `#root/Home/HomeProjects`. These tags always start at the `#root` tag.
 
 Given our work-and-home project:
 

--- a/guide/Plugins/Directory Tree.md
+++ b/guide/Plugins/Directory Tree.md
@@ -12,12 +12,42 @@ The *Directory Tree* plugin automatically creates a [[folgezettel-heterarchy]] r
 
 Given a folder `./Project/HouseWarming/`, this plugin will create two zettels with [[id]] `Project` and `HouseWarming`. In the [[web]], neuron will display the "contents" of a directory beneath the zettel content.
 
-Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `family/notes` and `work/notes` will cause Neuron to attempt to generate two zettels with the ID `notes`, which will cause an error.
+Directory names must be **globally** unique across the entire zettelkasten, inasmuch they directly reflect [[id]] which must also be unique. This means that two directories or zettels with the same name but in different paths will not work: having both `family/notes` and `work/notes` will cause Neuron to attempt to generate two zettels with the ID `notes`, which will cause an error. In order to resolve this error, and to keep the zettel IDs [[atomic]], it would be better to rename **both** notes to `work/work-notes/` and `family/family-notes`.
 
 The zettel content for directory zettels are by default empty. However, you may explicitly specify them by creating zettel files using the same [[id]]; for the example above, you may create `./Project.md` and `./Project/HouseWarming.md` - and they will be "merged" to the auto-created directory zettels.
+
+### Generated notes are 'lifted' out of their directory hierarchy
+
+Notes whose files are located in a subdirectory, will be 'lifted' to the same level as the 'root'--at the same level as their parents and grandparents.
+
+For example, the following directory structure
+
+```
+└─programming
+  ├── ruby.md
+  ├── ruby
+  │   ├── rails.md
+  │   └── rspec-testing.md
+  └── functional-programming.md
+```
+
+would create the following HTML documents, all at the top-level of the generated Neuron site: 
+
+- `programming.html`
+- `ruby.html`
+- `rails.html`
+- `rspec-testing.html`
+- `functional-programming.html`
+
+Because a directory's name will become its zettel ID, and because all zettels are 'lifted' out of their path hierarchy when notes are generated, it is important to give it a clear and meaningful name (if you are using non-random IDs). 
+
+A zettel created by the directory `work/notes` is a bad zettel ID, because once at the 'top' level of the zettelkasten, the ID `notes` has lost the context provided by its parent directory. A better ID would be `work/work-notes`.
+
+While this might seem redundant at first glance, the rationale for this this lift is to keep the zettels [[atomic]], and to keep linking as simple as possible. To link to the `work-notes` zettel, you don't need to remember that it's in the `work/` directory--you just link to `[[work-notes]]`. And if you choose to move it in the future, you don't need to hunt down and remember to update links that have been made to it.
 
 ## Links & tags created
 
 A [[folgezettel-heterarchy]] is formed, reflecting the directory tree on disk, with the exception of the `index` zettel[^man]. The forming of links is based on hierarchical [[tags]] (reflecting the relative path), that every normal zettel and directory zettel is automatically tagged with.
 
 [^man]: You may manually form these relationships by adding `[[[z:zettels?tag=root]]]` to the top-level `index.md`
+


### PR DESCRIPTION
This PR adds documentation for the **Directory Tree** plugin explaining the rationale behind requiring that directory names be globally unique.

I started with your comment on the last PR, and tried to break it down and give more concrete detail. Hoping this works, and I'm more than happy to make changes to it.