### PR TITLE
Add label to the Home link

### DIFF
--- a/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
@@ -151,8 +151,9 @@ renderBottomMenu themeDyn mIndexZettel mEditUrl = do
       ffor x $ \case
         Nothing -> blank
         Just indexZettel -> do
-          neuronDynRouteLink (Some . Route_Zettel . Z.zettelSlug <$> indexZettel) ("class" =: "item" <> "title" =: "Home") $
+          neuronDynRouteLink (Some . Route_Zettel . Z.zettelSlug <$> indexZettel) ("class" =: "item" <> "title" =: "Home") $ do
             semanticIcon "home"
+            text " Home"
     -- Edit url
     forM_ mEditUrl $ \editUrl -> do
       let attrs = "href" =: editUrl <> "title" =: "Edit this page"


### PR DESCRIPTION
Resolves #342

This adds a "Home" label to the menu item.

Perhaps labels on all of the menu items? Is the "compact" style alright? I think it's OK as it is though.

Perhaps the Home item could have an icon in the impulse frontend? I could do that.

### Screenshot

1. Labelled home button and DOM

![Screenshot from 2021-01-04 07-41-17](https://user-images.githubusercontent.com/1019641/103491727-cea31f80-4e71-11eb-8d08-246827c07cf0.png)

2. Illustration of label without space

![home-space](https://user-images.githubusercontent.com/1019641/103491892-f34bc700-4e72-11eb-819b-0bae0393ff05.gif)


