### PR TITLE
Speed up incremental generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     - By default, recursively read Markdown files in notes directory. This behaviour can be disabled via the neuronignore plugin.
 - Reduce error verbosity (CLI & web) in the scenario of there being innumerous broken wiki-links.
 - `neuron rib` is renamed to `neuron gen` (neuron has migrated from rib/shake to reflex)
+- Performance improvements:
+  - Improve incremental generation performance (`-w) (#522)
 
 ## Unreleased (v1 + v2)
 

--- a/dep/nixpkgs/github.json
+++ b/dep/nixpkgs/github.json
@@ -2,6 +2,6 @@
   "owner": "NixOS",
   "repo": "nixpkgs",
   "private": false,
-  "rev": "bea44d5ebe332260aa34a1bd48250b6364527356",
-  "sha256": "14sfk04iyvyh3jl1s2wayw1y077dwpk2d712nhjk1wwfjkdq03r3"
+  "rev": "cc8db6e19b876e0ee484d8e186fc689ce1e18f6b",
+  "sha256": "0d9skgf9c4k5114iwxq9y92ixavs5qkmyxgmnqaj3qxb00mg8dp4"
 }

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 1.9.3.0
+version: 1.9.4.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -188,6 +188,7 @@ library neuron-app-lib
     Options.Applicative.Extra
     Neuron.Backend
     Neuron.Reactor
+    Neuron.Reactor.Build
     Neuron.CLI.App
     Neuron.CLI.Logging
     Neuron.CLI.New

--- a/neuron/src/app/Neuron/CLI/App.hs
+++ b/neuron/src/app/Neuron/CLI/App.hs
@@ -80,8 +80,9 @@ runAppCommand genAct = do
         if cached
           then Cache.getCache
           else do
-            (ch, _, _) <- Reactor.loadZettelkasten
-            pure ch
+            Reactor.loadZettelkasten >>= \case
+              Left e -> fail $ toString e
+              Right (ch, _, _) -> pure ch
       case query of
         Left someQ ->
           withSome someQ $ \q -> do

--- a/neuron/src/app/Neuron/CLI/App.hs
+++ b/neuron/src/app/Neuron/CLI/App.hs
@@ -29,7 +29,6 @@ import Neuron.CLI.Search (interactiveSearch)
 import Neuron.CLI.Types
 import qualified Neuron.Cache as Cache
 import qualified Neuron.Cache.Type as Cache
-import Neuron.Config (getConfig)
 import qualified Neuron.Reactor as Reactor
 import qualified Neuron.Version as Version
 import qualified Neuron.Zettelkasten.Graph as G
@@ -73,7 +72,7 @@ runAppCommand genAct = do
         Nothing ->
           genAct watch
     New newCommand ->
-      newZettelFile newCommand =<< getConfig
+      newZettelFile newCommand
     Open openCommand ->
       openLocallyGeneratedFile openCommand
     Query QueryCommand {..} -> do
@@ -81,7 +80,7 @@ runAppCommand genAct = do
         if cached
           then Cache.getCache
           else do
-            (ch, _, _) <- Reactor.loadZettelkasten =<< getConfig
+            (ch, _, _) <- Reactor.loadZettelkasten
             pure ch
       case query of
         Left someQ ->

--- a/neuron/src/app/Neuron/CLI/Logging.hs
+++ b/neuron/src/app/Neuron/CLI/Logging.hs
@@ -96,3 +96,11 @@ mkLogAction =
       T.pack (setSGRCode [SetColor Foreground Vivid c])
         <> txt
         <> T.pack (setSGRCode [Reset])
+
+indentAllButFirstLine :: Int -> Text -> Text
+indentAllButFirstLine n = T.strip . unlines . go . lines
+  where
+    go [] = []
+    go [x] = [x]
+    go (x : xs) =
+      x : fmap (toText . (replicate n ' ' <>) . toString) xs

--- a/neuron/src/app/Neuron/CLI/New.hs
+++ b/neuron/src/app/Neuron/CLI/New.hs
@@ -21,8 +21,7 @@ import Data.Time.DateMayTime (DateMayTime, formatDateMayTime)
 import Neuron.CLI.Logging
 import Neuron.CLI.Types (MonadApp, NewCommand (..), getNotesDir)
 import qualified Neuron.Cache.Type as Cache
-import Neuron.Config.Type (Config (..))
-import Neuron.Reactor as Reactor
+import Neuron.Reactor as Reactor (loadZettelkasten)
 import qualified Neuron.Zettelkasten.Graph as G
 import Neuron.Zettelkasten.ID (zettelIDSourceFileName)
 import qualified Neuron.Zettelkasten.ID.Scheme as IDScheme
@@ -36,9 +35,9 @@ import System.Posix.Process (executeFile)
 -- | Create a new zettel file and open it in editor if requested
 --
 -- As well as print the path to the created file.
-newZettelFile :: (MonadIO m, MonadApp m, MonadFail m, WithLog env Message m) => NewCommand -> Config -> m ()
-newZettelFile NewCommand {..} config = do
-  (g, _, _) <- Reactor.loadZettelkasten config
+newZettelFile :: (MonadIO m, MonadApp m, MonadFail m, WithLog env Message m) => NewCommand -> m ()
+newZettelFile NewCommand {..} = do
+  (g, _, _) <- Reactor.loadZettelkasten
   mzid <- withSome idScheme $ \scheme -> do
     val <- liftIO $ IDScheme.genVal scheme
     pure $

--- a/neuron/src/app/Neuron/CLI/Types.hs
+++ b/neuron/src/app/Neuron/CLI/Types.hs
@@ -79,7 +79,7 @@ newtype App a = App (ReaderT (Env App) IO a)
 
 instance MonadFail App where
   fail s = do
-    log EE $ toText s
+    log EE $ indentAllButFirstLine 4 $ toText s
     exitFailure
 
 getAppEnv :: App (Env App)

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -15,7 +15,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Neuron.Config
-  ( getConfig,
+  ( getConfigFromFile,
+    onMissingConfigFile,
     parsePure,
   )
 where
@@ -32,30 +33,28 @@ import Neuron.CLI.Logging
 import Neuron.CLI.Types (MonadApp, getNotesDir)
 import Neuron.Config.Type (Config, configFile, defaultConfig, mergeWithDefault)
 import Relude
-import System.Directory (doesFileExist)
-import System.FilePath ((</>))
 
 deriving instance FromDhall Config
 
--- | Read the optional @neuron.dhall@ config file from the zettelkasten
-getConfig :: (MonadIO m, MonadFail m, MonadApp m, WithLog env Message m) => m Config
-getConfig = do
-  notesDir <- getNotesDir
-  let configPath = notesDir </> configFile
-  configVal :: Text <-
-    liftIO (doesFileExist configPath) >>= \case
-      True -> do
-        s <- readFileText configPath
-        -- Accept empty neuron.dhall (used to signify a directory to be used with neuron)
+getConfigFromFile :: (MonadIO m, MonadFail m) => FilePath -> m Config
+getConfigFromFile configPath = do
+  s <- readFileText configPath
+  -- Accept empty neuron.dhall (used to signify a directory to be used with neuron)
+  let configVal =
         if T.null (T.strip s)
-          then pure defaultConfig
-          else pure $ mergeWithDefault s
-      False -> do
-        log E $ "You must add a neuron.dhall to " <> toText notesDir
-        log E "You can add one by running:"
-        log E $ "  touch " <> toText notesDir <> "/neuron.dhall"
-        fail "Not a neuron notes directory"
-  either fail pure $ parsePure configFile $ mergeWithDefault configVal
+          then defaultConfig
+          else mergeWithDefault s
+  either fail pure $
+    parsePure configFile $ mergeWithDefault configVal
+
+-- TODO: Start usin this in reflex app
+onMissingConfigFile :: (MonadFail m, MonadApp m, WithLog env Message m) => m a
+onMissingConfigFile = do
+  notesDir <- getNotesDir
+  log E $ "You must add a neuron.dhall to " <> toText notesDir
+  log E "You can add one by running:"
+  log E $ "  touch " <> toText notesDir <> "/neuron.dhall"
+  fail "Not a neuron notes directory"
 
 -- | Pure version of `Dhall.input Dhall.auto`
 --

--- a/neuron/src/app/Neuron/Config.hs
+++ b/neuron/src/app/Neuron/Config.hs
@@ -43,7 +43,6 @@ getConfigFromFile configPath = do
           else mergeWithDefault s
   pure $ first toText $ parsePure configFile $ mergeWithDefault configVal
 
--- TODO: Start usin this in reflex app
 missingConfigError :: FilePath -> Text
 missingConfigError notesDir = do
   T.intercalate

--- a/neuron/src/app/Neuron/Reactor.hs
+++ b/neuron/src/app/Neuron/Reactor.hs
@@ -12,7 +12,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | React to the world, and build our Zettelkasten
--- TODO: Split this module appropriately.
 module Neuron.Reactor
   ( generateSite,
     loadZettelkasten,
@@ -21,53 +20,27 @@ where
 
 import Colog (WithLog, log)
 import Control.Monad.Fix (MonadFix)
-import Control.Monad.Writer.Strict (runWriter, tell)
 import qualified Data.Dependent.Map as DMap
 import Data.Dependent.Sum (DSum ((:=>)))
 import Data.List (nubBy)
-import qualified Data.Map.Strict as Map
-import Data.Some (Some (Some), foldSome)
 import Data.Time (NominalDiffTime)
 import Neuron.CLI.Logging
 import Neuron.CLI.Types
-import qualified Neuron.Cache as Cache
 import Neuron.Cache.Type (NeuronCache)
 import qualified Neuron.Cache.Type as Cache
-import qualified Neuron.Config as Config
 import Neuron.Config.Type (Config)
-import qualified Neuron.Config.Type as Config
-import qualified Neuron.Frontend.Manifest as Manifest
-import Neuron.Frontend.Route (Route (Route_Impulse, Route_ImpulseStatic, Route_Zettel), routeHtmlPath)
-import qualified Neuron.Frontend.Route as Z
-import qualified Neuron.Frontend.Route.Data as RD
-import qualified Neuron.Frontend.Static.HeadHtml as HeadHtml
-import qualified Neuron.Frontend.Static.Html as Html
-import qualified Neuron.Frontend.Widget as W
-import Neuron.Plugin (PluginRegistry)
-import qualified Neuron.Plugin as Plugin
+import Neuron.Frontend.Route (Route (Route_Impulse, Route_ImpulseStatic, Route_Zettel))
 import qualified Neuron.Plugin.Plugins.NeuronIgnore as NeuronIgnore
-import Neuron.Version (neuronVersion)
-import qualified Neuron.Zettelkasten.Graph.Build as G
-import Neuron.Zettelkasten.Graph.Type (ZettelGraph, stripSurroundingContext)
-import Neuron.Zettelkasten.ID (ZettelID (..))
-import qualified Neuron.Zettelkasten.Resolver as R
+import qualified Neuron.Reactor.Build as RB
 import Neuron.Zettelkasten.Zettel (ZettelC)
-import qualified Neuron.Zettelkasten.Zettel as Z
-import Neuron.Zettelkasten.Zettel.Error
-  ( ZettelError (..),
-    ZettelIssue (..),
-    splitZettelIssues,
-    zettelErrorText,
-  )
 import Reflex.Dom.Core
 import Reflex.FSNotify (FSEvent, watchTree)
 import Reflex.Host.Headless (runHeadlessApp)
 import Relude
-import System.Directory (doesFileExist, makeAbsolute, withCurrentDirectory)
+import System.Directory (makeAbsolute)
 import qualified System.Directory.Contents as DC
-import qualified System.Directory.Contents.Extra as DC
 import qualified System.FSNotify as FSN
-import System.FilePath (isRelative, makeRelative, takeExtension, (</>))
+import System.FilePath (isRelative, makeRelative)
 
 generateSite :: Bool -> App ()
 generateSite continueWatching = do
@@ -83,7 +56,7 @@ reflexApp ::
   Env App ->
   m (Event t ())
 reflexApp appEnv = do
-  let run :: App a -> m a
+  let run :: forall m1 a. MonadIO m1 => App a -> m1 a
       run a = liftIO $ runApp appEnv a
   -- Build a dynamic of directory tree
   treeOrErrorDyn <- eitherDyn =<< buildDirTreeDyn appEnv
@@ -93,7 +66,6 @@ reflexApp appEnv = do
         -- Display neuron.dhall errors
         dyn $
           ffor errDyn $ \err ->
-            -- TODO: Just return error as is, and handle it at top-level.
             run $ do
               log EE "Config file error"
               log E $ indentAllButFirstLine 4 err
@@ -101,24 +73,24 @@ reflexApp appEnv = do
         -- Build route data
         routeDataWithErrorsE <- dyn $
           ffor treeDyn $ \(cfg, tree') -> do
-            (cache, zs, fileTree) <- run $ loadZettelkastenFromFiles cfg tree'
-            routeData <- run $ buildRouteData fileTree zs cache
+            (cache, zs, fileTree) <- run $ RB.loadZettelkastenFromFiles cfg tree'
+            routeData <- run $ RB.buildRouteData fileTree zs cache
             pure (routeData, Cache._neuronCache_errors cache)
-        -- Do everything now.
+        -- Remember last route data, so we know what to render to save time.
         routeDataWithErrorsE' <- rememberLastEvent (mempty, mempty) routeDataWithErrorsE
+        -- Do everything now.
         done <- performEvent $
           ffor (attach (current $ snd <$> treeDyn) routeDataWithErrorsE') $ \(filesTree, ((oldRoutes, _oldErrs), (newRoutes, newErrors))) -> do
             -- Copy static files
-            nStatic <- liftIO $ runApp appEnv $ copyStaticFiles filesTree
+            nStatic <- run $ RB.copyStaticFiles filesTree
             -- Write modified routes
             nRoutes <- case modifiedRoutesOnly oldRoutes newRoutes of
-              Just rs -> liftIO $ runApp appEnv $ writeRoutes rs
+              Just rs -> run $ RB.writeRoutes rs
               Nothing -> pure 0
             -- Report errors
-            liftIO $ runApp appEnv $ reportAllErrors newErrors
+            run $ RB.reportAllErrors newErrors
             pure $ nRoutes + nStatic
-
-        -- let done = fforMaybe (mergeWith combine [doneRoutesE, doneStaticFilesE, doneErrsE]) id
+        -- Report finish status
         widgetHold_ blank $
           ffor done $ \n' ->
             run $ do
@@ -133,146 +105,40 @@ reflexApp appEnv = do
       xDyn <- holdDyn x evt
       pure $ attach (current xDyn) evt
     modifiedRoutesOnly :: [DSum Route Identity] -> [DSum Route Identity] -> Maybe (NonEmpty (DSum Route Identity))
-    modifiedRoutesOnly old new =
-      let oldMap = DMap.fromList old
-          modified :: [DSum Route Identity] =
+    modifiedRoutesOnly (DMap.fromList -> oldMap) new =
+      let needsRebuild :: forall a. Eq a => Route a -> Identity a -> Maybe ()
+          needsRebuild r newVal =
+            case DMap.lookup r oldMap of
+              Just oldVal -> guard (oldVal /= newVal)
+              Nothing -> Just ()
+       in nonEmpty $
             fforMaybe new $ \case
-              -- TODO: Refactor this for DRY
-              rd@(r@(Route_Zettel _) :=> newVal) ->
-                case DMap.lookup r oldMap of
-                  Just oldVal -> guard (oldVal /= newVal) >> pure rd
-                  Nothing -> pure rd
-              rd@(r@(Route_Impulse _) :=> newVal) ->
-                case DMap.lookup r oldMap of
-                  Just oldVal -> guard (oldVal /= newVal) >> pure rd
-                  Nothing -> pure rd
-              rd@(r@Route_ImpulseStatic :=> newVal) ->
-                case DMap.lookup r oldMap of
-                  Just oldVal -> guard (oldVal /= newVal) >> pure rd
-                  Nothing -> pure rd
-          _removed = DMap.toList $ DMap.difference oldMap oldMap
-       in nonEmpty modified
-
-writeRoutes :: NonEmpty (DSum Route Identity) -> App Int
-writeRoutes new = do
-  log D $ "Rendering routes (" <> show (length new) <> " slugs) ..."
-  -- TODO: Reflex static renderer is our main bottleneck. Memoize it using route data.
-  -- Second bottleneck is graph building.
-  !routeHtml <- forM new $ \case
-    r@(Z.Route_Zettel _) :=> Identity val -> do
-      (Some r,) <$> genRouteHtml r val
-    r@(Z.Route_Impulse _) :=> Identity val ->
-      (Some r,) <$> genRouteHtml r val
-    r@Z.Route_ImpulseStatic :=> Identity val ->
-      (Some r,) <$> genRouteHtml r val
-  -- log D "Writing to disk ..."
-  fmap sum $
-    forM routeHtml $ \(someR, html) -> do
-      fmap (bool 0 1) $ flip writeRouteHtml html `foldSome` someR
-
-copyStaticFiles :: (MonadApp m, MonadIO m, WithLog env Message m) => DC.DirTree FilePath -> m Int
-copyStaticFiles fileTree = do
-  case DC.walkContents "static" fileTree of
-    Just staticTree@(DC.DirTree_Dir _ _) -> do
-      notesDir <- getNotesDir
-      outputDir <- getOutputDir
-      DC.rsyncDir notesDir outputDir staticTree
-    _ ->
-      pure 0
+              rd@(r@(Route_Zettel _) :=> newVal) -> do
+                needsRebuild r newVal
+                pure rd
+              rd@(r@(Route_Impulse _) :=> newVal) -> do
+                needsRebuild r newVal
+                pure rd
+              rd@(r@Route_ImpulseStatic :=> newVal) -> do
+                needsRebuild r newVal
+                pure rd
 
 buildDirTreeDyn :: (MonadIO (Performable m), MonadIO m, PerformEvent t m, TriggerEvent t m, PostBuild t m, MonadHold t m, MonadFix m) => Env App -> m (Dynamic t (Either Text (Config, DC.DirTree FilePath)))
 buildDirTreeDyn appEnv = do
-  (notesDir, tree0) <- liftIO $
-    runApp appEnv $ do
-      (,) <$> getNotesDir <*> locateZettelFiles
+  let run :: forall m1 a. MonadIO m1 => App a -> m1 a
+      run a = liftIO $ runApp appEnv a
+  (notesDir, tree0) <-
+    run $ (,) <$> getNotesDir <*> RB.locateZettelFiles
   fsEventsE <- watchDirWithDebounce 0.1 notesDir
   treeE <- performEvent $
     ffor fsEventsE $ \(fmap FSN.eventPath -> paths) ->
-      liftIO $
-        runApp appEnv $ do
-          forM_ paths $ \path ->
-            log (I' Received) $ toText path
-          -- TODO(perf): Instead of rebuilding the tree, patch the existing tree
-          -- with changed paths.
-          locateZettelFiles
+      run $ do
+        forM_ paths $ \path ->
+          log (I' Received) $ toText path
+        -- TODO(perf): Instead of rebuilding the tree, patch the existing tree
+        -- with changed paths.
+        RB.locateZettelFiles
   holdDyn tree0 treeE
-
-buildRouteData :: (MonadIO m, MonadApp m, WithLog env Message m) => DC.DirTree FilePath -> [ZettelC] -> NeuronCache -> m [DSum Route Identity]
-buildRouteData fileTree zs cache = do
-  log D "Building route data ..."
-  headHtml <- HeadHtml.getHeadHtmlFromTree fileTree
-  let manifest = Manifest.mkManifestFromTree fileTree
-      siteData = RD.mkSiteData cache headHtml manifest
-      impulseData = RD.mkImpulseData cache
-      impulseRouteData = (siteData, impulseData)
-      mkZettelRoute zC =
-        let z = Z.sansContent zC
-            zettelData = RD.mkZettelData cache zC
-         in Z.Route_Zettel (Z.zettelSlug z) :=> Identity (siteData, zettelData)
-      !routes =
-        (Z.Route_Impulse Nothing :=> Identity impulseRouteData) :
-        (Z.Route_ImpulseStatic :=> Identity impulseRouteData) :
-        fmap mkZettelRoute zs
-  pure routes
-
--- Report all errors
--- TODO: Report only new errors in this run, to avoid spamming the terminal.
-reportAllErrors ::
-  forall m env.
-  (MonadIO m, WithLog env Message m) =>
-  Map ZettelID ZettelIssue ->
-  m ()
-reportAllErrors issues = do
-  let (errors, badLinks) = splitZettelIssues issues
-  whenNotNull badLinks $ \_ -> do
-    let zn = length badLinks
-        ln = length $ concat $ toList . snd . snd <$> badLinks
-    log W $ show ln <> " missing links found across " <> show zn <> " notes (see Impulse)"
-  uncurry reportError `mapM_` errors
-  where
-    -- Report an error in the terminal
-    reportError :: ZettelID -> ZettelError -> m ()
-    reportError zid (zettelErrorText -> err) = do
-      -- We don't know the full path to this zettel; so just print the ID.
-      log EE $ "Cannot accept Zettel ID: " <> unZettelID zid
-      log E $ indentAllButFirstLine 4 err
-
-genRouteHtml ::
-  forall m a.
-  MonadIO m =>
-  Route a ->
-  a ->
-  m ByteString
-genRouteHtml r val = do
-  -- We do this verbose dance to make sure hydration happens only on Impulse route.
-  -- Ideally, this should be abstracted out, but polymorphic types are a bitch.
-  liftIO $ case r of
-    Route_Impulse {} ->
-      fmap snd . renderStatic . runHydratableT $ do
-        -- FIXME: Injecting initial value here will break hydration on Impulse.
-        let valDyn = constDyn $ W.unavailableData @a
-        Html.renderRoutePage r valDyn
-    _ ->
-      fmap snd . renderStatic $ do
-        let valDyn = constDyn $ W.availableData val
-        Html.renderRoutePage r valDyn
-
-writeRouteHtml :: (MonadApp m, MonadIO m, WithLog env Message m) => Route a -> ByteString -> m Bool
-writeRouteHtml r content = do
-  outputDir <- getOutputDir
-  let htmlFile = outputDir </> routeHtmlPath r
-  -- DOCTYPE declaration is helpful for code that might appear in the user's `head.html` file (e.g. KaTeX).
-  let s = decodeUtf8 @Text $ "<!DOCTYPE html>" <> content
-  s0 <- liftIO $ do
-    doesFileExist htmlFile >>= \case
-      True -> Just <$> readFileText htmlFile
-      False -> pure Nothing
-  if Just s /= s0
-    then do
-      log (I' Sent) $ toText $ DC.mkRelative outputDir htmlFile
-      writeFileText htmlFile s
-      pure True
-    else pure False
 
 -- | Like `watchDir` but batches file events
 --
@@ -327,93 +193,7 @@ watchDirWithDebounce ms dirPath' = do
           -- Tack in a "./" to be directory-contents friendly
           pure $ "./" <> rel
 
--- Functions from old Generate.hs
-
 loadZettelkasten ::
   (MonadIO m, MonadApp m, WithLog env Message m) =>
   m (Either Text (NeuronCache, [ZettelC], DC.DirTree FilePath))
-loadZettelkasten = do
-  -- TODO Instead of logging here, put this info in Impulse footer.
-  locateZettelFiles >>= \case
-    Left e -> pure $ Left e
-    Right (config, fileTree) ->
-      Right <$> loadZettelkastenFromFiles config fileTree
-
-loadZettelkastenFromFiles :: (WithLog env Message m, MonadApp m, MonadIO m) => Config -> DC.DirTree FilePath -> m (NeuronCache, [ZettelC], DC.DirTree FilePath)
-loadZettelkastenFromFiles config fileTree = do
-  let plugins = Config.getPlugins config
-  log D $ "Plugins enabled: " <> Plugin.pluginRegistryShow plugins
-  ((g, zs), errs) <- loadZettelkastenFromFilesWithPlugins plugins fileTree
-  let cache = Cache.NeuronCache g errs config neuronVersion
-      cacheSmall = cache {Cache._neuronCache_graph = stripSurroundingContext g}
-  Cache.updateCache cacheSmall
-  pure (cache, zs, fileTree)
-
-locateZettelFiles :: (MonadIO m, MonadApp m) => m (Either Text (Config, DC.DirTree FilePath))
-locateZettelFiles = do
-  -- Run with notes dir as PWD, so that DirTree uses relative paths throughout.
-  d <- getNotesDir
-  liftIO $
-    withCurrentDirectory d $
-      -- Building with "." as root directory ensures that the returned tree
-      -- structure consistently uses the "./" prefix for all paths. This
-      -- assumption then holds elsewhere in neuron.
-      DC.buildDirTree "." >>= \case
-        Just t -> do
-          -- Look for neuron.dhall
-          case DC.walkContents "neuron.dhall" t of
-            Just (DC.DirTree_File _ dhallFp) -> do
-              Config.getConfigFromFile dhallFp >>= \case
-                Left e ->
-                  pure $ Left e
-                Right config ->
-                  Plugin.filterSources (Config.getPlugins config) t >>= \case
-                    Nothing ->
-                      pure $ Left "No source files to process"
-                    Just tF ->
-                      pure $ Right (config, tF)
-            _ ->
-              pure $ Left $ Config.missingConfigError d
-        Nothing ->
-          pure $ Left "Empty directory"
-
--- | Load the Zettelkasten from disk, using the given list of zettel files
-loadZettelkastenFromFilesWithPlugins ::
-  (MonadIO m, MonadApp m, WithLog env Message m) =>
-  PluginRegistry ->
-  DC.DirTree FilePath ->
-  m
-    ( ( ZettelGraph,
-        [ZettelC]
-      ),
-      Map ZettelID ZettelIssue
-    )
-loadZettelkastenFromFilesWithPlugins plugins fileTree = do
-  !zidRefs <-
-    case DC.pruneDirTree =<< DC.filterDirTree ((== ".md") . takeExtension) fileTree of
-      Nothing ->
-        pure mempty
-      Just mdFileTree -> do
-        let total = getSum @Int $ foldMap (const $ Sum 1) mdFileTree
-        -- TODO: Would be nice to show a progressbar here
-        -- liftIO $ DC.printDirTree fileTree
-        log D $ "Loading directory tree (" <> show total <> " .md files) ..."
-        fmap snd $
-          flip runStateT Map.empty $ do
-            flip R.resolveZidRefsFromDirTree mdFileTree $ \relPath -> do
-              absPath <- fmap (</> relPath) getNotesDir
-              decodeUtf8With lenientDecode <$> readFileBS absPath
-            Plugin.afterZettelRead plugins mdFileTree
-  log D $ "Building graph (" <> show (length zidRefs) <> " notes) ..."
-  pure $
-    runWriter $ do
-      filesWithContent <-
-        flip Map.traverseMaybeWithKey zidRefs $ \zid -> \case
-          R.ZIDRef_Ambiguous fps -> do
-            tell $ one (zid, ZettelIssue_Error $ ZettelError_AmbiguousID fps)
-            pure Nothing
-          R.ZIDRef_Available fp s pluginData ->
-            pure $ Just (fp, (s, pluginData))
-      let !zs = Plugin.afterZettelParse plugins (Map.toList filesWithContent)
-      !g <- G.buildZettelkasten zs
-      pure (g, zs)
+loadZettelkasten = RB.loadZettelkasten

--- a/neuron/src/app/Neuron/Reactor/Build.hs
+++ b/neuron/src/app/Neuron/Reactor/Build.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | React to the world, and build our Zettelkasten
+-- TODO: Split this module appropriately.
+module Neuron.Reactor.Build where
+
+import Colog (WithLog, log)
+import Control.Monad.Writer.Strict (runWriter, tell)
+import Data.Dependent.Sum (DSum ((:=>)))
+import qualified Data.Map.Strict as Map
+import Data.Some (Some (Some), foldSome)
+import Neuron.CLI.Logging
+import Neuron.CLI.Types
+import qualified Neuron.Cache as Cache
+import Neuron.Cache.Type (NeuronCache)
+import qualified Neuron.Cache.Type as Cache
+import qualified Neuron.Config as Config
+import Neuron.Config.Type (Config)
+import qualified Neuron.Config.Type as Config
+import qualified Neuron.Frontend.Manifest as Manifest
+import Neuron.Frontend.Route (Route (Route_Impulse), routeHtmlPath)
+import qualified Neuron.Frontend.Route as Z
+import qualified Neuron.Frontend.Route.Data as RD
+import qualified Neuron.Frontend.Static.HeadHtml as HeadHtml
+import qualified Neuron.Frontend.Static.Html as Html
+import qualified Neuron.Frontend.Widget as W
+import Neuron.Plugin (PluginRegistry)
+import qualified Neuron.Plugin as Plugin
+import Neuron.Version (neuronVersion)
+import qualified Neuron.Zettelkasten.Graph.Build as G
+import Neuron.Zettelkasten.Graph.Type (ZettelGraph, stripSurroundingContext)
+import Neuron.Zettelkasten.ID (ZettelID (..))
+import qualified Neuron.Zettelkasten.Resolver as R
+import Neuron.Zettelkasten.Zettel (ZettelC)
+import qualified Neuron.Zettelkasten.Zettel as Z
+import Neuron.Zettelkasten.Zettel.Error
+  ( ZettelError (..),
+    ZettelIssue (..),
+    splitZettelIssues,
+    zettelErrorText,
+  )
+import Reflex.Dom.Core
+import Relude
+import System.Directory (doesFileExist, withCurrentDirectory)
+import qualified System.Directory.Contents as DC
+import qualified System.Directory.Contents.Extra as DC
+import System.FilePath (takeExtension, (</>))
+
+writeRoutes :: NonEmpty (DSum Route Identity) -> App Int
+writeRoutes new = do
+  log D $ "Rendering routes (" <> show (length new) <> " slugs) ..."
+  -- TODO: Reflex static renderer is our main bottleneck. Memoize it using route data.
+  -- Second bottleneck is graph building.
+  !routeHtml <- forM new $ \case
+    r@(Z.Route_Zettel _) :=> Identity val -> do
+      (Some r,) <$> genRouteHtml r val
+    r@(Z.Route_Impulse _) :=> Identity val ->
+      (Some r,) <$> genRouteHtml r val
+    r@Z.Route_ImpulseStatic :=> Identity val ->
+      (Some r,) <$> genRouteHtml r val
+  -- log D "Writing to disk ..."
+  fmap sum $
+    forM routeHtml $ \(someR, html) -> do
+      fmap (bool 0 1) $ flip writeRouteHtml html `foldSome` someR
+
+copyStaticFiles :: (MonadApp m, MonadIO m, WithLog env Message m) => DC.DirTree FilePath -> m Int
+copyStaticFiles fileTree = do
+  case DC.walkContents "static" fileTree of
+    Just staticTree@(DC.DirTree_Dir _ _) -> do
+      notesDir <- getNotesDir
+      outputDir <- getOutputDir
+      DC.rsyncDir notesDir outputDir staticTree
+    _ ->
+      pure 0
+
+buildRouteData :: (MonadIO m, MonadApp m, WithLog env Message m) => DC.DirTree FilePath -> [ZettelC] -> NeuronCache -> m [DSum Route Identity]
+buildRouteData fileTree zs cache = do
+  log D "Building route data ..."
+  headHtml <- HeadHtml.getHeadHtmlFromTree fileTree
+  let manifest = Manifest.mkManifestFromTree fileTree
+      siteData = RD.mkSiteData cache headHtml manifest
+      impulseData = RD.mkImpulseData cache
+      impulseRouteData = (siteData, impulseData)
+      mkZettelRoute zC =
+        let z = Z.sansContent zC
+            zettelData = RD.mkZettelData cache zC
+         in Z.Route_Zettel (Z.zettelSlug z) :=> Identity (siteData, zettelData)
+      !routes =
+        (Z.Route_Impulse Nothing :=> Identity impulseRouteData) :
+        (Z.Route_ImpulseStatic :=> Identity impulseRouteData) :
+        fmap mkZettelRoute zs
+  pure routes
+
+-- Report all errors
+-- TODO: Report only new errors in this run, to avoid spamming the terminal.
+reportAllErrors ::
+  forall m env.
+  (MonadIO m, WithLog env Message m) =>
+  Map ZettelID ZettelIssue ->
+  m ()
+reportAllErrors issues = do
+  let (errors, badLinks) = splitZettelIssues issues
+  whenNotNull badLinks $ \_ -> do
+    let zn = length badLinks
+        ln = length $ concat $ toList . snd . snd <$> badLinks
+    log W $ show ln <> " missing links found across " <> show zn <> " notes (see Impulse)"
+  uncurry reportError `mapM_` errors
+  where
+    -- Report an error in the terminal
+    reportError :: ZettelID -> ZettelError -> m ()
+    reportError zid (zettelErrorText -> err) = do
+      -- We don't know the full path to this zettel; so just print the ID.
+      log EE $ "Cannot accept Zettel ID: " <> unZettelID zid
+      log E $ indentAllButFirstLine 4 err
+
+genRouteHtml ::
+  forall m a.
+  MonadIO m =>
+  Route a ->
+  a ->
+  m ByteString
+genRouteHtml r val = do
+  -- We do this verbose dance to make sure hydration happens only on Impulse route.
+  -- Ideally, this should be abstracted out, but polymorphic types are a bitch.
+  liftIO $ case r of
+    Route_Impulse {} ->
+      fmap snd . renderStatic . runHydratableT $ do
+        -- FIXME: Injecting initial value here will break hydration on Impulse.
+        let valDyn = constDyn $ W.unavailableData @a
+        Html.renderRoutePage r valDyn
+    _ ->
+      fmap snd . renderStatic $ do
+        let valDyn = constDyn $ W.availableData val
+        Html.renderRoutePage r valDyn
+
+writeRouteHtml :: (MonadApp m, MonadIO m, WithLog env Message m) => Route a -> ByteString -> m Bool
+writeRouteHtml r content = do
+  outputDir <- getOutputDir
+  let htmlFile = outputDir </> routeHtmlPath r
+  -- DOCTYPE declaration is helpful for code that might appear in the user's `head.html` file (e.g. KaTeX).
+  let s = decodeUtf8 @Text $ "<!DOCTYPE html>" <> content
+  s0 <- liftIO $ do
+    doesFileExist htmlFile >>= \case
+      True -> Just <$> readFileText htmlFile
+      False -> pure Nothing
+  if Just s /= s0
+    then do
+      log (I' Sent) $ toText $ DC.mkRelative outputDir htmlFile
+      writeFileText htmlFile s
+      pure True
+    else pure False
+
+-- Functions from old Generate.hs
+
+loadZettelkasten ::
+  (MonadIO m, MonadApp m, WithLog env Message m) =>
+  m (Either Text (NeuronCache, [ZettelC], DC.DirTree FilePath))
+loadZettelkasten = do
+  locateZettelFiles >>= \case
+    Left e -> pure $ Left e
+    Right (config, fileTree) ->
+      Right <$> loadZettelkastenFromFiles config fileTree
+
+loadZettelkastenFromFiles :: (WithLog env Message m, MonadApp m, MonadIO m) => Config -> DC.DirTree FilePath -> m (NeuronCache, [ZettelC], DC.DirTree FilePath)
+loadZettelkastenFromFiles config fileTree = do
+  let plugins = Config.getPlugins config
+  log D $ "Plugins enabled: " <> Plugin.pluginRegistryShow plugins
+  ((g, zs), errs) <- loadZettelkastenFromFilesWithPlugins plugins fileTree
+  let cache = Cache.NeuronCache g errs config neuronVersion
+      cacheSmall = cache {Cache._neuronCache_graph = stripSurroundingContext g}
+  Cache.updateCache cacheSmall
+  pure (cache, zs, fileTree)
+
+locateZettelFiles :: (MonadIO m, MonadApp m) => m (Either Text (Config, DC.DirTree FilePath))
+locateZettelFiles = do
+  -- Run with notes dir as PWD, so that DirTree uses relative paths throughout.
+  d <- getNotesDir
+  liftIO $
+    withCurrentDirectory d $
+      -- Building with "." as root directory ensures that the returned tree
+      -- structure consistently uses the "./" prefix for all paths. This
+      -- assumption then holds elsewhere in neuron.
+      DC.buildDirTree "." >>= \case
+        Just t -> do
+          -- Look for neuron.dhall
+          case DC.walkContents "neuron.dhall" t of
+            Just (DC.DirTree_File _ dhallFp) -> do
+              Config.getConfigFromFile dhallFp >>= \case
+                Left e ->
+                  pure $ Left e
+                Right config ->
+                  Plugin.filterSources (Config.getPlugins config) t >>= \case
+                    Nothing ->
+                      pure $ Left "No source files to process"
+                    Just tF ->
+                      pure $ Right (config, tF)
+            _ ->
+              pure $ Left $ Config.missingConfigError d
+        Nothing ->
+          pure $ Left "Empty directory"
+
+-- | Load the Zettelkasten from disk, using the given list of zettel files
+loadZettelkastenFromFilesWithPlugins ::
+  (MonadIO m, MonadApp m, WithLog env Message m) =>
+  PluginRegistry ->
+  DC.DirTree FilePath ->
+  m
+    ( ( ZettelGraph,
+        [ZettelC]
+      ),
+      Map ZettelID ZettelIssue
+    )
+loadZettelkastenFromFilesWithPlugins plugins fileTree = do
+  !zidRefs <-
+    case DC.pruneDirTree =<< DC.filterDirTree ((== ".md") . takeExtension) fileTree of
+      Nothing ->
+        pure mempty
+      Just mdFileTree -> do
+        let total = getSum @Int $ foldMap (const $ Sum 1) mdFileTree
+        -- TODO: Would be nice to show a progressbar here
+        -- liftIO $ DC.printDirTree fileTree
+        log D $ "Loading directory tree (" <> show total <> " .md files) ..."
+        fmap snd $
+          flip runStateT Map.empty $ do
+            flip R.resolveZidRefsFromDirTree mdFileTree $ \relPath -> do
+              absPath <- fmap (</> relPath) getNotesDir
+              decodeUtf8With lenientDecode <$> readFileBS absPath
+            Plugin.afterZettelRead plugins mdFileTree
+  log D $ "Building graph (" <> show (length zidRefs) <> " notes) ..."
+  pure $
+    runWriter $ do
+      filesWithContent <-
+        flip Map.traverseMaybeWithKey zidRefs $ \zid -> \case
+          R.ZIDRef_Ambiguous fps -> do
+            tell $ one (zid, ZettelIssue_Error $ ZettelError_AmbiguousID fps)
+            pure Nothing
+          R.ZIDRef_Available fp s pluginData ->
+            pure $ Just (fp, (s, pluginData))
+      let !zs = Plugin.afterZettelParse plugins (Map.toList filesWithContent)
+      !g <- G.buildZettelkasten zs
+      pure (g, zs)

--- a/neuron/src/lib/Data/TagTree.hs
+++ b/neuron/src/lib/Data/TagTree.hs
@@ -71,6 +71,7 @@ newtype Tag = Tag {unTag :: Text}
 newtype TagPattern = TagPattern {unTagPattern :: FilePattern}
   deriving
     ( Eq,
+      Ord,
       Show,
       Generic
     )
@@ -91,7 +92,7 @@ data TagQuery
   = TagQuery_And (NonEmpty TagPattern)
   | TagQuery_Or (NonEmpty TagPattern)
   | TagQuery_All
-  deriving (Eq, Generic)
+  deriving (Eq, Ord, Generic)
   deriving anyclass
     ( ToJSON,
       FromJSON

--- a/neuron/src/lib/Neuron/Frontend/Manifest.hs
+++ b/neuron/src/lib/Neuron/Frontend/Manifest.hs
@@ -13,19 +13,19 @@ module Neuron.Frontend.Manifest
   )
 where
 
+import Data.Default
 import qualified Data.Set as Set
 import Reflex.Dom.Core
 import Relude
 import qualified System.Directory.Contents as DC
-import Data.Default
 
 data Manifest = Manifest
   { manifestFavicons :: Maybe Favicons,
     manifestWebAppManifest :: Maybe FilePath
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
-instance Default Manifest where 
+instance Default Manifest where
   def = Manifest Nothing Nothing
 
 data Favicons = Favicons
@@ -33,7 +33,7 @@ data Favicons = Favicons
     faviconsAlts :: [FilePath],
     faviconsAppleTouch :: Maybe FilePath
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 mkManifestFromTree :: DC.DirTree FilePath -> Manifest
 mkManifestFromTree fileTree =

--- a/neuron/src/lib/Neuron/Frontend/Route.hs
+++ b/neuron/src/lib/Neuron/Frontend/Route.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -10,7 +12,11 @@
 -- | Neuron's route and its config
 module Neuron.Frontend.Route where
 
-import Data.GADT.Compare.TH (DeriveGEQ (deriveGEq))
+import Data.Constraint.Extras.TH (deriveArgDict)
+import Data.GADT.Compare.TH
+  ( DeriveGCompare (deriveGCompare),
+    DeriveGEQ (deriveGEq),
+  )
 import Data.GADT.Show.TH (DeriveGShow (deriveGShow))
 import Data.Some (Some, withSome)
 import Data.TagTree (Tag, unTag)
@@ -95,5 +101,6 @@ routeTitle' v = \case
     either zettelTitle zettelTitle $ zettelDataZettel . snd $ v
 
 deriveGEq ''Route
-
 deriveGShow ''Route
+deriveGCompare ''Route
+deriveArgDict ''Route

--- a/neuron/src/lib/Neuron/Frontend/Route/Data/Types.hs
+++ b/neuron/src/lib/Neuron/Frontend/Route/Data/Types.hs
@@ -40,7 +40,7 @@ import Text.URI (URI)
 type NeuronVersion = Tagged "NeuronVersion" Text
 
 newtype HeadHtml = HeadHtml (Maybe Text)
-  deriving (Eq)
+  deriving (Eq, Show)
 
 instance Default HeadHtml where
   def = HeadHtml Nothing
@@ -64,7 +64,7 @@ data SiteData = SiteData
     -- Reference to `index.md` zettel if any.
     siteDataIndexZettel :: Maybe Zettel
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data ZettelData = ZettelData
   { zettelDataZettel :: ZettelC,
@@ -88,6 +88,7 @@ data ImpulseData = ImpulseData
     impulseDataStats :: Stats,
     impulseDataPinned :: [Zettel]
   }
+  deriving (Eq, Show)
 
 data Stats = Stats
   { statsZettelCount :: Int,

--- a/neuron/src/lib/Neuron/Plugin/PluginData.hs
+++ b/neuron/src/lib/Neuron/Plugin/PluginData.hs
@@ -37,7 +37,7 @@ data DirZettel = DirZettel
     -- | The zettel associated with the parent directory.
     _dirZettel_dirParent :: Maybe ZettelID
   }
-  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
 -- Every zettel is associated with custom data for each plugin.
 -- TODO: Rename to PluginZettelData

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -107,12 +107,6 @@ sansLinkContext z =
   where
     stripContextFromZettelQuery (someQ, _ctx) = (someQ, mempty)
 
--- instance Eq (ZettelT c) where
---   (==) = (==) `on` zettelID
-
---instance Ord (ZettelT c) where
---  compare = compare `on` zettelID
-
 instance Show (ZettelT c) where
   show Zettel {..} = "Zettel:" <> show zettelID
 

--- a/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
+++ b/neuron/src/lib/Neuron/Zettelkasten/Zettel.hs
@@ -26,8 +26,6 @@ import Data.Constraint.Extras.TH (deriveArgDict)
 import Data.Dependent.Map (DMap)
 import Data.Dependent.Sum.Orphans ()
 import Data.GADT.Compare.TH
-  ( DeriveGEQ (deriveGEq),
-  )
 import Data.GADT.Show.TH (DeriveGShow (deriveGShow))
 import Data.Graph.Labelled (Vertex (..))
 import Data.Some (Some)
@@ -109,11 +107,11 @@ sansLinkContext z =
   where
     stripContextFromZettelQuery (someQ, _ctx) = (someQ, mempty)
 
-instance Eq (ZettelT c) where
-  (==) = (==) `on` zettelID
+-- instance Eq (ZettelT c) where
+--   (==) = (==) `on` zettelID
 
-instance Ord (ZettelT c) where
-  compare = compare `on` zettelID
+--instance Ord (ZettelT c) where
+--  compare = compare `on` zettelID
 
 instance Show (ZettelT c) where
   show Zettel {..} = "Zettel:" <> show zettelID
@@ -131,6 +129,7 @@ deriveJSONGADT ''ZettelQuery
 deriveGEq ''ZettelQuery
 
 deriveGShow ''ZettelQuery
+deriveGCompare ''ZettelQuery
 
 deriveArgDict ''ZettelQuery
 
@@ -145,6 +144,18 @@ deriving instance Eq (ZettelQuery (Maybe Zettel))
 deriving instance Eq (ZettelQuery [Zettel])
 
 deriving instance Eq (ZettelQuery (Map Tag Natural))
+
+deriving instance Eq (ZettelT Pandoc)
+
+deriving instance Eq (ZettelT MetadataOnly)
+
+deriving instance Eq (ZettelT (Text, ZettelParseError))
+
+deriving instance Ord (ZettelT Pandoc)
+
+deriving instance Ord (ZettelT MetadataOnly)
+
+deriving instance Ord (ZettelT (Text, ZettelParseError))
 
 deriving instance ToJSON Zettel
 


### PR DESCRIPTION
Avoid re-rendering of unchanged zettel routes when using `-w`. Use headless reflex network to propagate changes and render only changed routes. This is phase 1 of #321 - and more optimizations are to come.

With this PR, `neuron gen -w` will re-generate a bit faster when files are modified (no change has been made however to the _initial_ generation's performance).