### PR TITLE
`neuron search`: highlight matching line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@
 - CLI
   - `neuron rib` is renamed to `neuron gen` (neuron has migrated from rib/shake to reflex)
   - `neuron search`: full-text search uses exact matching (#526)
+  - `neuron search`: highlight and focus matching line in `bat` preview (#556)
   - `neuron query`: query CLI interface has been changed (see docs)
 - Performance improvements:
-  - Improve incremental generation performance (`-w) (#522)
+  - Improve incremental generation performance (`-w`) (#522)
 - Bug fixes
   - Fix a bug where folgezettel relationship is not established if a note also has non-folgezettel links to the same target
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 1.9.9.1
+version: 1.9.10.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -9,6 +9,8 @@ EXTENSIONS=${4}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${5})
 EXACT=""
 
+: ${NEURON_SEARCH_CONTEXT_ABOVE:=5}
+
 # Use --exact for full text search
 if [ -z "${FILTERBY}" ]; then
   EXACT="--exact"
@@ -25,5 +27,6 @@ cd ${NOTESDIR}
   | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,1 -u || cat )\
   | fzf ${EXACT} --tac --no-sort -d ':' -n ${SEARCHFROMFIELD}.. \
     --preview 'bat --style=plain --color=always --highlight-line={2} {1}' \
+    --preview-window ':+{2}-'"$NEURON_SEARCH_CONTEXT_ABOVE" \
   | awk -F: "{printf \"${NOTESDIR}/%s\", \$1}" \
   | xargs -I % ${OPENCMD} %

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -18,12 +18,12 @@ cd ${NOTESDIR}
 
 # The LC_ALL here is fix the "illegal byte sequence" error
 # See https://github.com/srid/neuron/pull/445#discussion_r513066111
-{   (rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" || echo) \
+{   (rg --no-heading --line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" || echo) \
   && rg --no-heading --no-line-number --with-filename --sort path "${FILTERBY}" -g "${EXTENSIONS}" \
-     --files-without-match | awk '{ printf "%s:# %s\n", $0, $0}'; } \
-  | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,2 -r || cat ) \
+     --files-without-match | awk '{ printf "%s:0:# %s\n", $0, $0}'; } \
+  | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,3 -r || cat ) \
   | ( [ ${FILTERBY} ] && LC_ALL=C sort -t: -k1,1 -u || cat )\
   | fzf ${EXACT} --tac --no-sort -d ':' -n ${SEARCHFROMFIELD}.. \
-    --preview 'bat --style=plain --color=always {1}' \
+    --preview 'bat --style=plain --color=always --highlight-line={2} {1}' \
   | awk -F: "{printf \"${NOTESDIR}/%s\", \$1}" \
   | xargs -I % ${OPENCMD} %

--- a/neuron/src-bash/neuron-search
+++ b/neuron/src-bash/neuron-search
@@ -9,7 +9,7 @@ EXTENSIONS=${4}
 OPENCMD=$(envsubst -no-unset -no-empty <<<${5})
 EXACT=""
 
-: ${NEURON_SEARCH_CONTEXT_ABOVE:=5}
+: ${NEURON_SEARCH_CONTEXT_ABOVE:=10}
 
 # Use --exact for full text search
 if [ -z "${FILTERBY}" ]; then


### PR DESCRIPTION
I found searching quite difficult, and had this in mind for a while.

These are only bash changes on how neuron interacts with `fzf` and `bat`

## Changes

- Highlight line with `bat --highlight-line`
- Changed FZF to focus on the line with `fzf --preview-window ':+5-5'`
- Made the focuse'd line configurable via `NEURON_SEARCH_CONTEXT_ABOVE` environment variable, but defaults to `10` (lines above search result) *(edit: changed from 5 to 10)*

## Preview

Before:

[![asciicast](https://asciinema.org/a/391208.svg)](https://asciinema.org/a/391208)

After:

[![asciicast](https://asciinema.org/a/391205.svg)](https://asciinema.org/a/391205)


