### PR TITLE
Add neuron-v2 vim plugin link

### DIFF
--- a/doc/Guide/Creating and Editing zettels/editor.md
+++ b/doc/Guide/Creating and Editing zettels/editor.md
@@ -12,6 +12,12 @@ Use the [vscode-memo](https://github.com/svsool/vscode-memo#memo) extension when
 
 ![demo](./static/vscode-title-id.gif){.ui .centered .large .image}
 
+## Vim 8/Neovim
+
+Forked version of the vim plugin below that has been updated to support Neuron v2:
+
+[neuron-v2.vim](https://github.com/chiefnoah/neuron-v2.vim)
+
 ## Editors known to work with v1
 
 These editors are known to work with version 1 of neuron. Your mileage may vary with the latest development version (version 2) of neuron.


### PR DESCRIPTION
Adds a link to my neuron-v2 vim8/neovim plugin. This plugin may be merged upstream later, but for now it's separate.

See [this issue](https://github.com/fiatjaf/neuron.vim/issues/62) for tracking the upstream bug report.