### PR TITLE
Use prism.js for syntax highlighting (and allow users to use a different one)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Remove autoscroll behaviour (which had questionable value to begin with)
   - Support alt text in images (#434)
 - Remove (experimental) support for org-mode in v2 (use `v1` branch if you need org-mode)
+- Use Prism.js for syntax highlighting, and allow users to use their own syntax highlighter (#560)
 - Plugin support
   - dirtree: Treat directories as zettels, forming automatic folgezettel connections to their children. (#497)
   - neuronignore: Exclude directories and markdown files via `.neuronignore`. (#499)

--- a/doc/Guide/Web interface/Customizing the generated website/Custom JavaScript and CSS.md
+++ b/doc/Guide/Web interface/Customizing the generated website/Custom JavaScript and CSS.md
@@ -2,8 +2,17 @@
 slug: custom-head
 ---
 
-You can add custom JavaSript or CSS code to the `<head>` element of the generated pages by adding it to the `head.html` file under the notes directory. If this file does not exist, neuron will use its builtin one that embeds MathJax JavaScript (see [[math]]).
+You can add custom JavaScript or CSS code to the `<head>` element of the generated pages by adding it to the `head.html` file under the notes directory. 
 
-Here are some of the interesting things you can do with this:
+If this file does not exist, neuron will use its builtin one that provides
+
+- MathJax JavaScript (see [[math]])
+- Prism JavaScript (see [[Code syntax Highlighting]])
+
+:::{.ui .message}
+Note that if you are going to specify a custom `head.html`, you must include the above manually.
+:::
+
+Here are some of the interesting things you can do with a custom `head.html`:
 
 [[z:zettels?tag=custom-head-recipe]]#

--- a/doc/Guide/Zettel Markdown.md
+++ b/doc/Guide/Zettel Markdown.md
@@ -13,7 +13,7 @@ Zettel files are written in Markdown, per [CommonMark](https://commonmark.org/) 
 Enriching Markdown:
 
 * [[raw-html]]#
-* [[2013702]]#
+* [[Code syntax Highlighting]]#
 * [[math]]#
 * [Footnotes](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/footnotes.md) and [many other extensions](https://github.com/jgm/commonmark-hs/tree/master/commonmark-extensions) are enabled.
 * **Highlighting**: Surround text with `== ... ==` to highlighting them (eg: This ==word== is highlighted).

--- a/doc/Guide/Zettel Markdown/2013702.md
+++ b/doc/Guide/Zettel Markdown/2013702.md
@@ -6,11 +6,18 @@ Syntax highlighting is builtin. To activate highlighting, your [fenced code bloc
 
 Tip: you can click the edit icon in the footer to the view source of this zettel.
 
+Haskell:
+
 ```haskell
--- This is Haskell
-main = do 
-  putStrLn $ show $ 2 + 2
+module Prime where 
+
+primes = filterPrime [2..]
+  where 
+    filterPrime (p:xs) =
+      p : filterPrime [x | x <- xs, x `mod` p /= 0]
 ```
+
+JSON:
 
 ```json
 { "_comment" : "This is JSON"
@@ -19,19 +26,45 @@ main = do
 }
 ```
 
-```mediawiki
-This is mediawiki, the format used by ''Wikipedia''.
+Nix:
 
-== Heading ==
-
-Statement 1. {{cite oed|wiki}}
+```nix
+buildPythonPackage rec {
+  pname = "hello";
+  version = "1.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01ba..0";
+  };
+}
 ```
+
+Markdown:
+
+```markdown
+This is `markdown`, the *format* used by **Neuron**
+
+# Heading
+
+- Link to [neuron](https://neuron.zettel.page)
+- [[Wiki Link]] is not official Markdown syntax
+```
+
+Matlab:
 
 ```matlab
 % This is Matlab code
 data = T(:,{'Year','Month','DayofMonth','UniqueCarrier'});
 data.Date = datetime(data.Year,data.Month,data.DayofMonth);
 data.UniqueCarrier = categorical(data.UniqueCarrier);
+```
+
+This one has no language identifier specified:
+
+```
+Just plain text.
+
+No particular syntax.
 ```
 
 ## Languages supported

--- a/doc/Guide/Zettel Markdown/Code syntax Highlighting.md
+++ b/doc/Guide/Zettel Markdown/Code syntax Highlighting.md
@@ -2,7 +2,9 @@
 slug: syntax-highlighting
 ---
 
-Syntax highlighting is builtin. To activate highlighting, your [fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) must contain a language identifier (see [example](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting)).
+Neuron provides syntax highlighting through [Prism](https://prismjs.com/), a JavaScript library that highlights code blocks in the web browser. To customize Prism's theme, or to provide your own syntax highlighter, you can do so in `head.html` (see [[Custom JavaScript and CSS]]).
+
+To active syntax highlighting, you must specify the language in your [fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) (see [example here](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting)) or view source of the below.
 
 ## Example
 

--- a/doc/Guide/Zettel Markdown/Code syntax Highlighting.md
+++ b/doc/Guide/Zettel Markdown/Code syntax Highlighting.md
@@ -1,4 +1,6 @@
-# Code syntax highlighting
+---
+slug: syntax-highlighting
+---
 
 Syntax highlighting is builtin. To activate highlighting, your [fenced code blocks](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#fenced-code-blocks) must contain a language identifier (see [example](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks#syntax-highlighting)).
 

--- a/neuron/neuron.cabal
+++ b/neuron/neuron.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: neuron
 -- This version must be in sync with what's in Default.dhall
-version: 1.9.11.0
+version: 1.9.12.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron/src/app/Neuron/Frontend/Static/HeadHtml.hs
+++ b/neuron/src/app/Neuron/Frontend/Static/HeadHtml.hs
@@ -39,8 +39,19 @@ getHeadHtml = do
 
 renderHeadHtml :: (DomBuilder t m, RawBuilder m) => HeadHtml -> m ()
 renderHeadHtml (HeadHtml headHtml) = case headHtml of
-  Nothing ->
-    -- Include the MathJax script if no custom head.html is provided.
-    elAttr "script" ("id" =: "MathJax-script" <> "src" =: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" <> "async" =: "") blank
+  Nothing -> do
+    -- If the user doesn't specify a head.html, we provide sensible defaults.
+    -- For Math support:
+    js' 
+      ("id" =: "MathJax-script" <> "async" =: "")  
+      "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+    -- For syntax highlighting:
+    css "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css"
+    js "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"
+    js "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"
   Just html ->
     elRawHtml html
+  where 
+    css x = elAttr "link" ("rel" =: "stylesheet" <> "href" =: x) blank
+    js = js' mempty
+    js' attrs x = elAttr "script" (attrs <> "src" =: x) blank

--- a/neuron/src/app/Neuron/Frontend/Static/HeadHtml.hs
+++ b/neuron/src/app/Neuron/Frontend/Static/HeadHtml.hs
@@ -46,7 +46,7 @@ renderHeadHtml (HeadHtml headHtml) = case headHtml of
       ("id" =: "MathJax-script" <> "async" =: "")  
       "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
     -- For syntax highlighting:
-    css "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css"
+    css "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism-okaidia.min.css"
     js "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-core.min.js"
     js "https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"
   Just html ->

--- a/neuron/src/lib/Neuron/Frontend/Zettel/CSS.hs
+++ b/neuron/src/lib/Neuron/Frontend/Zettel/CSS.hs
@@ -112,14 +112,7 @@ zettelContentCss = do
         C.backgroundColor "#f8f8f8"
       -- This selects block code elements
       pre ? do
-        sym C.padding $ em 0.5
         C.overflow auto
-        C.maxWidth $ pct 100
-      "div.pandoc-code" ? do
-        C.marginLeft auto
-        C.marginRight auto
-        pre ? do
-          C.backgroundColor "#f8f8f8"
     -- https://css-tricks.com/snippets/css/simple-and-nice-blockquote-styling/
     blockquoteStyle =
       C.blockquote ? do

--- a/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
@@ -133,7 +133,7 @@ mkReflexDomPandocConfig x =
         -- to detect the language.
         -- 
         -- If no language is specified, use "none" as the language (i.e.,
-        -- language-text). This works at least on prism.js,[1] in that - syntax
+        -- language-none). This works at least on prism.js,[1] in that - syntax
         -- highlighting is turned off all the while background styling is
         -- applied, to be consistent with code blocks with language set.
         -- 

--- a/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
@@ -129,11 +129,18 @@ mkReflexDomPandocConfig x =
           Plugin.renderHandleLink (R.zettelDataPlugin x) url minner,
       _config_renderCode = \_ (_, langs, _) s -> do
         -- Tag code block with "language-foo" class, if the user specified "foo"
-        -- as the language identifier. This enables external syntax highlightier
-        -- detect the language.
-        let highlightJsClass =
-              maybe "plaintext" (("language-" <>) . head) $ nonEmpty langs
-        el "pre" $ elClass "code" highlightJsClass $ text s,
+        -- as the language identifier. This enables external syntax highlighters
+        -- to detect the language.
+        -- 
+        -- If no language is specified, use "none" as the language (i.e.,
+        -- language-text). This works at least on prism.js,[1] in that - syntax
+        -- highlighting is turned off all the while background styling is
+        -- applied, to be consistent with code blocks with language set.
+        -- 
+        -- [1] https://github.com/PrismJS/prism/pull/2738
+        let langClass =
+              maybe "language-none" (("language-" <>) . head) $ nonEmpty langs
+        el "pre" $ elClass "code" langClass $ text s,
       _config_renderRaw = elPandocRaw
     }
 

--- a/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
+++ b/neuron/src/lib/Neuron/Frontend/Zettel/View.hs
@@ -45,7 +45,7 @@ import Reflex.Dom.Pandoc
   )
 import qualified Reflex.Dom.Pandoc as PR
 import Reflex.Dom.Pandoc.Raw (RawBuilder, elPandocRaw)
-import Relude hiding (traceShowId, (&))
+import Relude hiding ((&))
 import Text.Pandoc.Definition (Pandoc)
 
 renderZettel ::
@@ -123,12 +123,17 @@ mkReflexDomPandocConfig ::
   ZettelData ->
   Config t (NeuronWebT t m) ()
 mkReflexDomPandocConfig x =
-  PR.defaultConfig
+  (PR.defaultConfig @t @m)
     { _config_renderLink = \oldRender url _attrs minner -> do
         fromMaybe oldRender $
           Plugin.renderHandleLink (R.zettelDataPlugin x) url minner,
-      -- _config_renderCode = \_ _attrs s -> do
-      --  el "code" $ text s
+      _config_renderCode = \_ (_, langs, _) s -> do
+        -- Tag code block with "language-foo" class, if the user specified "foo"
+        -- as the language identifier. This enables external syntax highlightier
+        -- detect the language.
+        let highlightJsClass =
+              maybe "plaintext" (("language-" <>) . head) $ nonEmpty langs
+        el "pre" $ elClass "code" highlightJsClass $ text s,
       _config_renderRaw = elPandocRaw
     }
 


### PR DESCRIPTION
Resolves #542

- [x] Use prism.js by default
- [x] Default styling of code blocks without language identifier
- [ ] Include user-added attrs, instead of ignoring them
- [x] Documentation: 
  - explain how to change syntax highlighter via `head.html`
  - use slug
