### PR TITLE
Add zk to the user-contributed utilities

### DIFF
--- a/doc/Guide/extras.md
+++ b/doc/Guide/extras.md
@@ -5,7 +5,8 @@ Some neuron users have developed scripts and tools to improve on the base functi
 [neuron-extras](https://github.com/b0o/neuron-extras) by Maddison Hellstrom
 : auto-generate a Table of Contents / hierarchical index based on hierarchical [[Tags]]
 
-[neuron-helper] by ybaumy
+[neuron-helper](https://github.com/zettelzottel/neuron-helper) by ybaumy
 : export ebook and article highlights from Readwise.io to neuron Markdown, etc.
 
-[neuron-helper]: https://github.com/zettelzottel/neuron-helper
+[zk](https://github.com/mickael-menu/zk) by Mickaël Menu
+: a command-line tool to manage a Zettelkasten with advanced filtering and note generation capabilities, [compatible with neuron](https://github.com/mickael-menu/zk/blob/main/docs/neuron.md).


### PR DESCRIPTION
[`zk`](https://github.com/mickael-menu/zk) is a command-line tool helping you to maintain a plain text Zettelkasten or personal wiki.

While there is some overlap with neuron's features, both tools are actually useful when paired together:

* Neuron shines with its static website generation
* `zk` has powerful [filtering](https://github.com/mickael-menu/zk/blob/main/docs/note-filtering.md) and [note generation](https://github.com/mickael-menu/zk/blob/main/docs/note-creation.md) capabilities

Close integration with Neuron was thought through from the start when designing `zk`. For example, Neuron's [Folgezettel](https://neuron.zettel.page/folgezettel.html) syntax is supported: `[[[link]]]`, `#[[link]]` and `[[link]]#`.

But you can make your [`zk` notebook](https://github.com/mickael-menu/zk/blob/main/docs/notebook.md) even more tightly integrated with Neuron by:

* using the [same settings as Neuron](https://neuron.zettel.page/id.html) to generate the note IDs in the note configuration
    ```toml
    [note]
    filename = "{{id}}"
    id-charset = "hex"
    id-length = 8
    id-case = "lower"
    ```
* adding [command aliases](https://github.com/mickael-menu/zk/blob/main/docs/config-alias.md) for your frequently used `neuron` commands
    ```toml
    [alias]
    serve = "neuron gen -wS"
    gen = "neuron gen -o public"
    ```