### PR TITLE
flake.nix: add basic support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,10 @@ jobs:
       DOCKERTAG: latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v13
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
       # This also runs nix-build.
       - uses: cachix/cachix-action@v8
         with:
@@ -25,7 +28,13 @@ jobs:
       - name: Build 🔧
         run: |
           nix-build -j4 --no-out-link ci.nix
+          # Test default.nix
           nix-build -j4
+          # Test flake.nix
+          nix build --out-link flake-result
+      - name: Verify output of default.nix & flake.nix
+        run: |
+          [ $(readlink result) = $(readlink flake-result) ]
       - name: Retrieve neuron version
         run: |
           echo "NEURONVER=$(./result/bin/neuron --version)" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist-*
 .ghc.environment.*
 result
 result-2
+result-data
 .shake
 .neuron
 neuron.prof

--- a/ci.nix
+++ b/ci.nix
@@ -6,6 +6,6 @@ pkgs.recurseIntoAttrs {
   # Build both default.nix and shell.nix such that both derivations are
   # pushed to cachix. This allows the development workflow (bin/run, etc.) to
   # use cachix to full extent.
-  neuron = import ./default.nix {};
-  neuronShell = import ./shell.nix {};
+  neuron = import ./default.nix;
+  neuronShell = import ./shell.nix;
 }

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 { system ? builtins.currentSystem }:
 let
-  pkgs = import ./dep/nixpkgs { inherit system; };
+  pkgs = import ./nixpkgs.nix { inherit system; };
 in
 pkgs.recurseIntoAttrs {
   # Build both default.nix and shell.nix such that both derivations are

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,13 @@
-args@{ system ? builtins.currentSystem, ...}:
-let 
-  pkgs = import ./dep/nixpkgs { inherit system; } ;
-in (import ./project.nix { pkgs = pkgs; } ).neuron
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).defaultNix

--- a/dep/nixpkgs/default.nix
+++ b/dep/nixpkgs/default.nix
@@ -1,2 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-import (import ./thunk.nix)

--- a/dep/nixpkgs/github.json
+++ b/dep/nixpkgs/github.json
@@ -1,7 +1,0 @@
-{
-  "owner": "NixOS",
-  "repo": "nixpkgs",
-  "private": false,
-  "rev": "fcab19deb78fbb5ea24e19b133cf34358176396a",
-  "sha256": "1x78z784sqrkhjx82ca9zchsxhwyyx60yb7wx8gji48nrbw36ijq"
-}

--- a/dep/nixpkgs/thunk.nix
+++ b/dep/nixpkgs/thunk.nix
@@ -1,9 +1,0 @@
-# DO NOT HAND-EDIT THIS FILE
-let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
-  if !fetchSubmodules && !private then builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
-    inherit owner repo rev sha256 fetchSubmodules private;
-  };
-  json = builtins.fromJSON (builtins.readFile ./github.json);
-in fetch json

--- a/docker.nix
+++ b/docker.nix
@@ -7,7 +7,7 @@
 #       --argstr tag <image-tag>
 #   )
 let
-  pkgs = import ./dep/nixpkgs {};
+  pkgs = import ./nixpkgs.nix {};
   neuron = import ./.;
 in {
   name ? "sridca/neuron"

--- a/docker.nix
+++ b/docker.nix
@@ -8,7 +8,7 @@
 #   )
 let
   pkgs = import ./dep/nixpkgs {};
-  neuron = import ./. {};
+  neuron = import ./.;
 in {
   name ? "sridca/neuron"
 , tag ? "dev"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1617631617,
+        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1616084726,
+        "narHash": "sha256-WEYz+MoWkSgf6vwsD0z3nsOuIftJMYG6hDNjTdD56PQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fcab19deb78fbb5ea24e19b133cf34358176396a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fcab19deb78fbb5ea24e19b133cf34358176396a",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1617631617,
@@ -33,6 +49,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/fcab19deb78fbb5ea24e19b133cf34358176396a";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Future-proof note-taking and publishing based on Zettelkasten";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/fcab19deb78fbb5ea24e19b133cf34358176396a";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        project = import ./project.nix { inherit pkgs; };
+
+      in rec {
+        packages = { neuron = project.neuron; };
+        defaultPackage = packages.neuron;
+
+        apps = { neuron = flake-utils.lib.mkApp { drv = packages.neuron; }; };
+        defaultApp = apps.neuron;
+
+        devShell = project.shell;
+      });
+}

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: neuron
-version: 1.9.27.0
+version: 1.9.27.1
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nixpkgs = lock.nodes.nixpkgs.locked;
+
+in import (fetchTarball {
+  url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs.rev}.tar.gz";
+  sha256 = nixpkgs.narHash;
+})

--- a/project.nix
+++ b/project.nix
@@ -1,5 +1,5 @@
 let
-  nixpkgs = import ./dep/nixpkgs {};
+  nixpkgs = import ./nixpkgs.nix {};
 in {
   pkgs ? nixpkgs,
   pkgsForBins ? null,

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,13 @@
-args@{ ... }: (import ./project.nix args).shell
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).shellNix

--- a/static.nix
+++ b/static.nix
@@ -1,7 +1,7 @@
 args@{...}:
 let 
   # FIXME: Use a nixpkgs that works with static builds
-  nixpkgs = import ./dep/nixpkgs args;
+  nixpkgs = import ./nixpkgs.nix args;
   pkgs = nixpkgs.pkgsMusl;
 in 
   (import ./project.nix { 


### PR DESCRIPTION
This should solve #485.

With this `flake.nix`, we can do...

- use `nix build` to build
- use `nix shell` to enter build shell
- use `nix run` to run `neuron` even without cloning project
  - for instance, `nix run "github:TheKK/neuron#neuron" -- open`

I also add `result-data` to `.gitignore` since it was created after running `nix build`. This make you to run `nix-build` to build same derivation after `nix build`.

If there's anything I can improve, please let me know!