### PR TITLE
Introduce JSONL format for query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   - `neuron query`:
     - query CLI interface has been changed (see docs)
     - JSON output is now pretty printed (using `aeson-pretty`)
+    - option to choose pretty printed JSON (default) or JSONL format (#612)
   - `neuron gen`: Add `--pretty-urls` to remove `.html` suffix in generated URLs (#562)
   - Supress colors if output is not a terminal with color support (#561)
 - Performance improvements:

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: neuron
-version: 1.9.29.0
+version: 1.9.30.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/src/Neuron/CLI/Parser.hs
+++ b/src/Neuron/CLI/Parser.hs
@@ -96,6 +96,7 @@ commandParser defaultNotesDir now = do
             (strOption (long "slug" <> help "Open the zettel HTML page" <> metavar "SLUG"))
     queryCommand = do
       cached <- switch (long "cached" <> help "Use cached zettelkasten graph (faster)")
+      jsonl <- switch (long "jsonl" <> help "output JSONL format (better for tool processing)")
       query <-
         fmap CliQuery_ById (option zettelIDReader (long "id" <> metavar "ID" <> help "Get a zettel by its ID"))
           <|> fmap (const CliQuery_Zettels) (switch $ long "zettels" <> help "Get all zettels")

--- a/src/Neuron/CLI/Types.hs
+++ b/src/Neuron/CLI/Types.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Neuron.CLI.Types
@@ -42,9 +41,7 @@ import Colog
   )
 import Data.Some (Some (..))
 import Data.TagTree (Tag)
-import Data.Time.DateMayTime
-  ( DateMayTime,
-  )
+import Data.Time.DateMayTime (DateMayTime)
 import Neuron.CLI.Logging
 import qualified Neuron.Frontend.Route as R
 import Neuron.Zettelkasten.ID (ZettelID)
@@ -143,6 +140,7 @@ data CliQuery
 data QueryCommand = QueryCommand
   { -- Use cache instead of building the zettelkasten from scratch
     cached :: Bool,
+    jsonl :: Bool,
     query :: CliQuery
   }
   deriving (Eq, Show)


### PR DESCRIPTION
To support querying by tools which expects whole information on one
line. E.g. Neovim telescope plugin where I need to query neuron DB returns result split on multiple lines. Which is nice for human, however impose burden on program interaction.

This PR introduces the --jsonl flag to 'query' sub-command. If this flag is active one entry will be printed at each line. 
Which is super convenient format for command line processing.

Example
```
neuron/doc $ /nix/store/i5lagbbinqf4i5b77liz3qp5spih98nd-neuron-1.9.27.2/bin/neuron query  --id index
   Plugins enabled: dirtree, links, tags, uptree
   Loading directory tree (49 .md files) ...
   Building graph (49 notes) ...
[
    {
        "ID": "index",
        "Meta": {
            "dirtree": {
                "display": false
            },
            "tags": []
        },
        "Path": "./index.md",
        "Slug": "index",
        "Title": "Neuron Zettelkasten"
    }
]
```
After
```
neuron/doc $ /nix/store/i5lagbbinqf4i5b77liz3qp5spih98nd-neuron-1.9.27.2/bin/neuron query --jsonl --id index
   Plugins enabled: dirtree, links, tags, uptree
   Loading directory tree (49 .md files) ...
   Building graph (49 notes) ...
{"Path":"./index.md","Slug":"index","ID":"index","Meta":{"dirtree":{"display":false},"tags":[]},"Title":"Neuron Zettelkasten"}
```