### PR TITLE
Add zettel metadata to HTML head <meta>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@
 - Clean HTML output when zettels are deleted (#141)
 - Added '§' character in whitelist (#595)
 - Normalize unicode filenames to NFC, fixing broken wiki links.
-- Added `<meta>` element to each page's HTML head, containing the zettel page's slug ID
-  - will be of the form: `<meta content="my-slug-id" property="neuron:zettel-id">`
+- Added `<meta>` element to each page's HTML head, containing certain useful metadata
+  - can take the following forms:
+    - `<meta content="my page id" property="neuron:zettel-id">`
+    - `<meta content="my-slug-id" property="neuron:zettel-slug">`
 
 ## Unreleased (v1 + v2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 - Clean HTML output when zettels are deleted (#141)
 - Added '§' character in whitelist (#595)
 - Normalize unicode filenames to NFC, fixing broken wiki links.
+- Added `<meta>` element to each page's HTML head, containing the zettel page's slug ID
+  - will be of the form: `<meta content="my-slug-id" property="neuron:zettel-id">`
 
 ## Unreleased (v1 + v2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,14 @@
 - Normalize unicode filenames to NFC, fixing broken wiki links.
 - Added `<meta>` element to each page's HTML head, containing certain useful metadata
   - can take the following forms:
-    - `<meta content="my page id" property="neuron:zettel-id">`
-    - `<meta content="my-slug-id" property="neuron:zettel-slug">`
+  ```html
+  <meta content="my page id" property="neuron:zettel-id">
+  <meta content="my-slug-id" property="neuron:zettel-slug">
+  <meta content="tag1" property="neuron:zettel-tag">
+  <meta content="tag2" property="neuron:zettel-tag">
+  <meta content="tag3" property="neuron:zettel-tag">
+  <!-- etc... -->
+  ```
 
 ## Unreleased (v1 + v2)
 

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: neuron
-version: 1.9.28.0
+version: 1.9.29.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/src/Neuron/Frontend/Static/StructuredData.hs
+++ b/src/Neuron/Frontend/Static/StructuredData.hs
@@ -20,15 +20,20 @@ import Data.Structured.OpenGraph
     OpenGraph (..),
   )
 import Data.Structured.OpenGraph.Render (renderOpenGraph)
+import Data.TagTree (unTag)
 import qualified Data.Text as T
 import Neuron.Frontend.Route (Route (..))
 import qualified Neuron.Frontend.Route as R
 import Neuron.Frontend.Route.Data.Types (zettelDataZettel)
 import qualified Neuron.Frontend.Route.Data.Types as R
 import qualified Neuron.Plugin as Plugin
+import qualified Neuron.Plugin.Plugins.Tags as Tags
 import Neuron.Zettelkasten.ID (unZettelID)
 import Neuron.Zettelkasten.Zettel
-  ( ZettelT (..),
+  ( PluginZettelData (Links),
+    Zettel,
+    ZettelT (..),
+    sansContent,
   )
 import Reflex.Dom.Core
 import Relude
@@ -43,10 +48,13 @@ renderStructuredData routeCfg route val = do
   case route of
     R.Route_Zettel zslug ->
       do
-        let zdata = zettelDataZettel (snd val)
-        let zid = unZettelID (either zettelID zettelID zdata)
+        let z :: Zettel = sansContent $ R.zettelDataZettel $ snd val
+        let zid = unZettelID $ zettelID z
+        let tags = Tags.getZettelTags z
         elAttr "meta" ("property" =: "neuron:zettel-id" <> "content" =: zid) blank
         elAttr "meta" ("property" =: "neuron:zettel-slug" <> "content" =: zslug) blank
+        forM_ tags $
+          \ztag -> elAttr "meta" ("property" =: "neuron:zettel-tag" <> "content" =: unTag ztag) blank
         forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
           Plugin.renderZettelHead routeCfg val
     _ -> blank

--- a/src/Neuron/Frontend/Static/StructuredData.hs
+++ b/src/Neuron/Frontend/Static/StructuredData.hs
@@ -23,8 +23,10 @@ import Data.Structured.OpenGraph.Render (renderOpenGraph)
 import qualified Data.Text as T
 import Neuron.Frontend.Route (Route (..))
 import qualified Neuron.Frontend.Route as R
+import Neuron.Frontend.Route.Data.Types (zettelDataZettel)
 import qualified Neuron.Frontend.Route.Data.Types as R
 import qualified Neuron.Plugin as Plugin
+import Neuron.Zettelkasten.ID (unZettelID)
 import Neuron.Zettelkasten.Zettel
   ( ZettelT (..),
   )
@@ -39,9 +41,12 @@ renderStructuredData :: DomBuilder t m => R.RouteConfig t m -> Route a -> a -> m
 renderStructuredData routeCfg route val = do
   renderOpenGraph $ routeOpenGraph routeCfg val route
   case route of
-    R.Route_Zettel zid ->
+    R.Route_Zettel zslug ->
       do
+        let zdata = zettelDataZettel (snd val)
+        let zid = unZettelID (either zettelID zettelID zdata)
         elAttr "meta" ("property" =: "neuron:zettel-id" <> "content" =: zid) blank
+        elAttr "meta" ("property" =: "neuron:zettel-slug" <> "content" =: zslug) blank
         forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
           Plugin.renderZettelHead routeCfg val
     _ -> blank

--- a/src/Neuron/Frontend/Static/StructuredData.hs
+++ b/src/Neuron/Frontend/Static/StructuredData.hs
@@ -46,17 +46,16 @@ renderStructuredData :: DomBuilder t m => R.RouteConfig t m -> Route a -> a -> m
 renderStructuredData routeCfg route val = do
   renderOpenGraph $ routeOpenGraph routeCfg val route
   case route of
-    R.Route_Zettel zslug ->
-      do
-        let z :: Zettel = sansContent $ R.zettelDataZettel $ snd val
-        let zid = unZettelID $ zettelID z
-        let tags = Tags.getZettelTags z
-        elAttr "meta" ("property" =: "neuron:zettel-id" <> "content" =: zid) blank
-        elAttr "meta" ("property" =: "neuron:zettel-slug" <> "content" =: zslug) blank
-        forM_ tags $
-          \ztag -> elAttr "meta" ("property" =: "neuron:zettel-tag" <> "content" =: unTag ztag) blank
-        forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
-          Plugin.renderZettelHead routeCfg val
+    R.Route_Zettel zslug -> do
+      let z :: Zettel = sansContent $ R.zettelDataZettel $ snd val
+          zid = zettelID z
+          tags = Tags.getZettelTags z
+      elAttr "meta" ("property" =: "neuron:zettel-id" <> "content" =: unZettelID zid) blank
+      elAttr "meta" ("property" =: "neuron:zettel-slug" <> "content" =: zslug) blank
+      forM_ tags $ \tag -> 
+        elAttr "meta" ("property" =: "neuron:zettel-tag" <> "content" =: unTag tag) blank
+      forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
+        Plugin.renderZettelHead routeCfg val
     _ -> blank
 
 routeOpenGraph :: R.RouteConfig t m -> a -> Route a -> OpenGraph

--- a/src/Neuron/Frontend/Static/StructuredData.hs
+++ b/src/Neuron/Frontend/Static/StructuredData.hs
@@ -28,7 +28,7 @@ import qualified Neuron.Plugin as Plugin
 import Neuron.Zettelkasten.Zettel
   ( ZettelT (..),
   )
-import Reflex.Dom.Core (DomBuilder, blank)
+import Reflex.Dom.Core
 import Relude
 import Text.Pandoc.Definition (Inline (Image), Pandoc (..))
 import Text.Pandoc.Util (getFirstParagraphText, plainify)
@@ -39,9 +39,11 @@ renderStructuredData :: DomBuilder t m => R.RouteConfig t m -> Route a -> a -> m
 renderStructuredData routeCfg route val = do
   renderOpenGraph $ routeOpenGraph routeCfg val route
   case route of
-    R.Route_Zettel _ ->
-      forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
-        Plugin.renderZettelHead routeCfg val
+    R.Route_Zettel zid ->
+      do
+        elAttr "meta" ("property" =: "neuron:zettel-id" <> "content" =: zid) blank
+        forM_ (DMap.toList (R.zettelDataPlugin (snd val))) $
+          Plugin.renderZettelHead routeCfg val
     _ -> blank
 
 routeOpenGraph :: R.RouteConfig t m -> a -> Route a -> OpenGraph


### PR DESCRIPTION
In order to make javascript-based tools which can effectively work with `cache.json` and transform certain things for the page, having zettel metadata somewhere in the HTML would be useful. At a minimum, the zettel slug ID is all that's required to cross-reference against `cache.json`.

Just to get the ball rolling, I've added `<meta>` elements (for the page ID, slug ID, and each tag) in the the head section for every zettel (thanks for the pointers @srid !).

The elements will be of the form
```html
<meta content="my page id" property="neuron:zettel-id">
<meta content="my-slug-id" property="neuron:zettel-slug">
<meta content="tag1" property="neuron:zettel-tag">
<meta content="tag2" property="neuron:zettel-tag">
<meta content="tag3" property="neuron:zettel-tag">
```