### PR TITLE
Add named wikilink processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Plugin:links
   - Labelled directional links (#514): `[[foo]]#` and `#[[foo]]`
   - Backlinks panel now groups entries by connection type
+  - Support explicit link text using pipes, as in `[[link|text to display]]`
 - Plugin:neuronigonre
   - Ignore `.neuron` and `.git` in any subdirectories
   - Ignore watching `.neuron` and `.git` directories in file watcher (-w)

--- a/doc/Guide/Plugins/Linking.md
+++ b/doc/Guide/Plugins/Linking.md
@@ -11,6 +11,8 @@ Place that zettel's [[id]] inside `[[..]]`.
 In [[Web interface]], neuron will automatically display the title of the
 linked zettel.
 
+Alternate link text can also be given using a pipe, as in `[[link|text to display]]`.
+
 ## Folgezettel links
 
 Wiki-links may be labelled as "folgezettel" if you are writing a "structure note" (or hub note, or index note). See [[Folgezettel Links]].

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: neuron
-version: 1.9.30.0
+version: 1.9.31.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -79,6 +79,7 @@ common library-common
     reflex-fsnotify,
     reflex,
     relude,
+    split,
     shower,
     tagged,
     text,


### PR DESCRIPTION
Let me know if there are any issues.

I didn't add tests because there are currently no tests for parsing the wikilinks anyway.

This is technically a breaking change if anyone has pipes in their wikilinks, but I don't think that's a huge problem.

There's also both styles of `[[url|name]]` and `[[name|url]]` in use; I went with the former because it works better with the defaults in the recommended VSCode configuration.

Resolves #373