### PR TITLE
Provide homeManagerModule as a flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,6 @@
         packages = { neuron = project.neuron; };
         defaultPackage = packages.neuron;
 
-        apps = { neuron = flake-utils.lib.mkApp { drv = packages.neuron; }; };
-        defaultApp = apps.neuron;
-
         devShell = project.shell;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,9 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+    {
+      homeManagerModule = import ./home-manager-module.nix;
+    } // flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         project = import ./project.nix { inherit pkgs; };

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+  ;
+
+  cfg = config.services.neuron;
+in
+{
+  options = {
+    services.neuron = {
+      enable = mkEnableOption ''
+        Future-proof note-taking and publishing based on Zettelkasten
+      '';
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.neuron-notes;
+        defaultText = "pkgs.neuron-notes";
+        description = "neuron derivation to use";
+      };
+
+      notesDirectory = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/home/\${name}/zettelkasten";
+        description = "Directory that holds the neuron notes";
+      };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "The hostname or IP address the HTTP server should listen to";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8080;
+        description = "Port the HTTP server should listen to";
+      };
+
+      prettyUrls = mkOption {
+        type = types.bool;
+        default = false;
+        description = "If set, drops the .html at the end of Zettel URLs.";
+      };
+
+      systemdTarget = mkOption {
+        type = types.str;
+        default = "graphical-session.target";
+        description = "Systemd target to bind to";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.notesDirectory != null;
+        message = "`services.neuron.notesDirectory' must be set.";
+      }
+    ];
+
+    systemd.user.services.neuron = {
+      Unit = {
+        Description = "Neuron zettelkasten service";
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
+      };
+
+      Service = {
+        Type = "exec";
+        ExecStart = ''
+          ${cfg.package}/bin/neuron \
+            -d ${cfg.notesDirectory} \
+            gen \
+            --watch \
+            --serve ${cfg.host}:${toString cfg.port} \
+            ${lib.optionalString cfg.prettyUrls "--pretty-urls"}
+        '';
+      };
+
+      Install = {
+        WantedBy = [ cfg.systemdTarget ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Main change is the added home-manager module, which can be used like 
```
    neuron = {
      enable = true;
      notesDirectory = "/home/${name}/zettelkasten";
      prettyUrls = true;
    };
```
See https://github.com/divnix/devos/issues/106#issuecomment-782914232 for pointers about how to add a home-manager module from a flake to `imports`.

I also removed the unnecessary app definitions, since by default `nix run` will try the packages with the same name. App definitions are mainly useful if there are multiple binaries or you want to name them differently.