### PR TITLE
Document Apple Silicon support and bump to 1.9.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased (v2)
 
+- Add Apple Silicon (aarch64-darwin) support (#677)
+- Upgrade to GHC 9.10 (#677)
 - Web interface
   - Introducing *impulse* -- foundation for upcoming advanced search, replacing both z-index and legacy JS search (#108)
   - Remove autoscroll behaviour (which had questionable value to begin with)

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
                   '';
                 });
                 fsnotify = dontCheck hsuper.fsnotify;
+                tls = dontCheck hsuper.tls;
                 # witherable 0.4.x (has Data.Witherable module)
                 witherable = doJailbreak (hself.callHackageDirect {
                   pkg = "witherable";

--- a/neuron.cabal
+++ b/neuron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: neuron
-version: 1.9.36.0
+version: 1.9.37.0
 license: AGPL-3.0-only
 copyright: 2020 Sridhar Ratnakumar
 maintainer: srid@srid.ca


### PR DESCRIPTION
**The GHC 9.10 upgrade enables working Apple Silicon (aarch64-darwin) builds** — the previous GHC 8.10.6 pin didn't support aarch64-darwin, so this is effectively new platform support. Changelog and version bump to reflect that.